### PR TITLE
Behind a Proxy?

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -43,6 +43,17 @@
 		  <br>
 		  <br>
 		  <div>
+		  <label>Proxy Host:</label><input type="text" name="proxy_host" value="${config['proxy_host']}" size="20"><br>
+		  <i class="smalltext">Set this value if you are behind a proxy</i>
+		  </div>
+		  <br>
+		  <div>
+		  <label>Proxy Type:</label><input type="text" name="proxy_type" value="${config['proxy_type']}" size="10"><br>
+                  <i class="smalltext">http, https, etc</i>
+		  </div>
+		  <br>
+		  <br>
+		  <div>
 		  <label>Full Scan:</label><input type="checkbox" name="full_scan" value=1 ${config['full_scan']} />
 		  <br>
 		  <i class="smalltext">This will remove entries if ebooks are not found in the download location</i>

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -56,6 +56,9 @@ HTTP_ROOT = None
 HTTP_LOOK = None
 LAUNCH_BROWSER = False
 
+PROXY_HOST = None
+PROXY_TYPE = None
+
 SAB_HOST = None
 SAB_PORT = None
 SAB_SUBDIR=None
@@ -232,6 +235,7 @@ def initialize():
     with INIT_LOCK:
 
         global __INITIALIZED__, FULL_PATH, PROG_DIR, LOGLEVEL, DAEMON, DATADIR, CONFIGFILE, CFG, LOGDIR, HTTP_HOST, HTTP_PORT, HTTP_USER, HTTP_PASS, HTTP_ROOT, HTTP_LOOK, LAUNCH_BROWSER, LOGDIR, CACHEDIR, MATCH_RATIO, \
+	    PROXY_HOST, PROXY_TYPE, \
             IMP_ONLYISBN, IMP_PREFLANG, IMP_AUTOADD, SAB_HOST, SAB_PORT, SAB_SUBDIR, SAB_API, SAB_USER, SAB_PASS, DESTINATION_DIR, DESTINATION_COPY, DOWNLOAD_DIR, SAB_CAT, USENET_RETENTION, NZB_BLACKHOLEDIR, GR_API, GB_API, BOOK_API, \
             NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, NEWZNAB, NEWZNAB_HOST, NEWZNAB_API, NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, NEWZNAB2, NEWZNAB_HOST2, NEWZNAB_API2, EBOOK_TYPE, KAT, USENETCRAWLER, USENETCRAWLER_HOST, USENETCRAWLER_API, \
             VERSIONCHECK_INTERVAL, SEARCH_INTERVAL, SCAN_INTERVAL, EBOOK_DEST_FOLDER, EBOOK_DEST_FILE, MAG_DEST_FOLDER, MAG_DEST_FILE, USE_TWITTER, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
@@ -289,6 +293,10 @@ def initialize():
 
 
         LAUNCH_BROWSER = bool(check_setting_int(CFG, 'General', 'launch_browser', 1))
+	
+	PROXY_HOST = check_setting_str(CFG, 'General','proxy_host', '')
+	PROXY_TYPE = check_setting_str(CFG, 'General','proxy_type', '')
+
         LOGDIR = check_setting_str(CFG, 'General', 'logdir', '')
 
         IMP_PREFLANG = check_setting_str(CFG, 'General', 'imp_preflang', 'en, eng, en-US')
@@ -472,6 +480,8 @@ def config_write():
     new_config['General']['http_root'] = HTTP_ROOT
     new_config['General']['http_look'] = HTTP_LOOK
     new_config['General']['launch_browser'] = int(LAUNCH_BROWSER)
+    new_config['General']['proxy_host'] = PROXY_HOST
+    new_config['General']['proxy_type'] = PROXY_TYPE
     new_config['General']['logdir'] = LOGDIR
     new_config['General']['loglevel'] = int(LOGLEVEL)
 

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -35,6 +35,8 @@ class GoodReads:
 			try:
 				# Cache our request
 				request = urllib2.Request(set_url)
+				if lazylibrarian.PROXY_HOST:
+					request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 				request.add_header('User-Agent', USER_AGENT)
 				opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 				resp = opener.open(request)
@@ -142,6 +144,8 @@ class GoodReads:
 
 		# Cache our request
 		request = urllib2.Request(URL)
+		if lazylibrarian.PROXY_HOST:
+			request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 		request.add_header('User-Agent', USER_AGENT)
 		opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 		resp = opener.open(request)
@@ -174,6 +178,8 @@ class GoodReads:
 
 		# Cache our request
 		request = urllib2.Request(URL)
+		if lazylibrarian.PROXY_HOST:
+			request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 		request.add_header('User-Agent', USER_AGENT)
 		opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 		resp = opener.open(request)
@@ -216,6 +222,8 @@ class GoodReads:
 		try:
 			# Cache our request
 			request = urllib2.Request(URL)
+			if lazylibrarian.PROXY_HOST:
+				request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 			request.add_header('User-Agent', USER_AGENT)
 			opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 			resp = opener.open(request)
@@ -279,6 +287,8 @@ class GoodReads:
 							try:
 								# Cache our request
 								request = urllib2.Request(BOOK_URL)
+								if lazylibrarian.PROXY_HOST:
+									request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 								request.add_header('User-Agent', USER_AGENT)
 								opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 								resp = opener.open(request)
@@ -380,6 +390,8 @@ class GoodReads:
 				try:
 					# Cache our request
 					request1 = urllib2.Request(URL)
+					if lazylibrarian.PROXY_HOST:
+						request1.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 					request1.add_header('User-Agent', USER_AGENT)
 					opener1 = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 					resp1 = opener1.open(request1)
@@ -440,6 +452,8 @@ class GoodReads:
 		try:
 			# Cache our request
 			request = urllib2.Request(URL)
+			if lazylibrarian.PROXY_HOST:
+				request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
 			request.add_header('User-Agent', USER_AGENT)
 			opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
 			resp = opener.open(request)

--- a/lazylibrarian/providers.py
+++ b/lazylibrarian/providers.py
@@ -195,6 +195,8 @@ def NewzNab(book=None, newznabNumber=None):
 
     try :
         request = urllib2.Request(URL)
+	if lazylibrarian.PROXY_HOST:
+		request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
         request.add_header('User-Agent', USER_AGENT)
         opener = urllib2.build_opener(SimpleCache.CacheHandler(".ProviderCache"), SimpleCache.ThrottlingProcessor(5))
         resp = opener.open(request)
@@ -293,6 +295,8 @@ def NewzNabPlus(book=None, host=None, api_key=None, searchType=None):
 
     try :
         request = urllib2.Request(URL)
+	if lazylibrarian.PROXY_HOST:
+		request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
         request.add_header('User-Agent', USER_AGENT)
         opener = urllib2.build_opener(SimpleCache.CacheHandler(".ProviderCache"), SimpleCache.ThrottlingProcessor(5))
         resp = opener.open(request)

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -152,6 +152,8 @@ def DownloadMethod(bookid=None, nzbprov=None, nzbtitle=None, nzburl=None):
 
         try:
             req = urllib2.Request(nzburl)
+	    if lazylibrarian.PROXY_HOST:
+	    	req.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
             req.add_header('User-Agent', USER_AGENT)
             nzbfile = urllib2.urlopen(req, timeout=90).read()
    

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -142,7 +142,10 @@ def DownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
     download = False
     if (lazylibrarian.USE_TOR):
         request = urllib2.Request(tor_url)
+	if lazylibrarian.PROXY_HOST:
+		request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
         request.add_header('Accept-encoding', 'gzip')
+	request.add_header('User-Agent', USER_AGENT)
     
         if tor_prov == 'KAT':
             request.add_header('Referer', 'http://kat.ph/')

--- a/lazylibrarian/utorrent.py
+++ b/lazylibrarian/utorrent.py
@@ -131,6 +131,8 @@ class utorrentclient(object):
     def _action(self, params, body=None, content_type=None):
         url = self.base_url + '/gui/' + '?token=' + self.token + '&' + urllib.urlencode(params)
         request = urllib2.Request(url)
+	if lazylibrarian.PROXY_HOST:
+		request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
         request.add_header('User-Agent', USER_AGENT)
 
         if body:

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -74,6 +74,8 @@ class WebInterface(object):
                     "http_look_list":   http_look_list,
                     "match_ratio":      lazylibrarian.MATCH_RATIO,
                     "launch_browser":   checked(lazylibrarian.LAUNCH_BROWSER),
+		    "proxy_host":	lazylibrarian.PROXY_HOST,
+		    "proxy_type":	lazylibrarian.PROXY_TYPE,
                     "logdir" :          lazylibrarian.LOGDIR,
                     "use_imp_onlyisbn": checked(lazylibrarian.IMP_ONLYISBN),
                     "imp_preflang":     lazylibrarian.IMP_PREFLANG,
@@ -146,7 +148,7 @@ class WebInterface(object):
         return serve_template(templatename="config.html", title="Settings", config=config)    
     config.exposed = True
 
-    def configUpdate(self, http_host='0.0.0.0', http_user=None, http_port=5299, http_pass=None, http_look=None, launch_browser=0, logdir=None, imp_onlyisbn=0, imp_preflang=None, imp_autoadd=None, match_ratio=80, nzb_downloader_sabnzbd=0, nzb_downloader_blackhole=0, use_nzb=0, use_tor=0,
+    def configUpdate(self, http_host='0.0.0.0', http_user=None, http_port=5299, http_pass=None, http_look=None, launch_browser=0, logdir=None, imp_onlyisbn=0, imp_preflang=None, imp_autoadd=None, match_ratio=80, nzb_downloader_sabnzbd=0, nzb_downloader_blackhole=0, use_nzb=0, use_tor=0, proxy_host=None, proxy_type=None,
         sab_host=None, sab_port=None, sab_subdir=None, sab_api=None, sab_user=None, sab_pass=None, destination_copy=0, destination_dir=None, download_dir=None, sab_cat=None, usenet_retention=None, nzb_blackholedir=None, torrent_dir=None, numberofseeders=0, tor_downloader_blackhole=0, tor_downloader_utorrent=0,
         newznab=0, newznab_host=None, newznab_api=None, newznab2=0, newznab_host2=None, newznab_api2=None,newzbin=0, newzbin_uid=None, newzbin_pass=None, kat=0, ebook_type=None, book_api=None, gr_api=None, gb_api=None, usenetcrawler = 0, usenetcrawler_host=None, usenetcrawler_api = None, 
         versioncheck_interval=None, search_interval=None, scan_interval=None, ebook_dest_folder=None, ebook_dest_file=None, mag_dest_folder=None, mag_dest_file=None, use_twitter=0, twitter_notify_onsnatch=0, twitter_notify_ondownload=0, utorrent_host=None, utorrent_user=None, utorrent_pass=None,  notfound_status='Wanted', full_scan=0, add_author=1, 
@@ -158,6 +160,8 @@ class WebInterface(object):
         lazylibrarian.HTTP_PASS = http_pass
         lazylibrarian.HTTP_LOOK = http_look
         lazylibrarian.LAUNCH_BROWSER = launch_browser
+	lazylibrarian.PROXY_HOST = proxy_host
+	lazylibrarian.PROXY_TYPE = proxy_type
         lazylibrarian.LOGDIR = logdir
         lazylibrarian.MATCH_RATIO = match_ratio
 


### PR DESCRIPTION
Allow use from behind a proxy.
proxy_type can be http, https etc.
proxy_host of the format http://user:pass@localhost:3128 
leave proxy_host blank for direct connection or environment settings.
