### PR TITLE
Fixed Library Sync author lookup

### DIFF
--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -103,7 +103,13 @@ def LibraryScan(dir=None):
 							authorlink  = author_gr['authorlink']
 							pageIdx = authorlink.rfind('/')
 							authorlink  = authorlink[pageIdx+1:]
-							match_auth = authorid+"."+author.replace('. ','_')
+							#match_auth = authorid+"."+author.replace('. ','_')
+							#Original Line does not allow author match.
+							match_auth = author.replace('.','_')
+                                                        match_auth = match_auth.replace(' ','_')
+                                                        match_auth = match_auth.replace('__','_')
+                                                        match_auth = authorid+"."+match_auth
+							# Hopefully someone can come up with a more efficient way of doing this.
 							logger.debug(match_auth)
 							logger.debug(authorlink)
 							if match_auth == authorlink:


### PR DESCRIPTION
The replace filter of ". " (period)(space) would fail to catch some authors whose directory name would be otherwise marked incorrect, it also seemed to have an effect on author names that were known good as it would find the author name matched in GoodReads but then would state that the author was not found in the database. This change fixes the issue and allows author import to work correctly.

Please note: I am not picking up the project, I am just a hobbyist that wanted to use this project and wanted to get it working again. I may contribute other patches in the future if I need to create any more.
