### PR TITLE
Fix for feedparser library inclusion

### DIFF
--- a/lazylibrarian/request.py
+++ b/lazylibrarian/request.py
@@ -18,7 +18,7 @@ from lazylibrarian import logger
 from xml.dom import minidom
 
 import request
-import feedparser
+import lib.feedparser as feedparser
 import lazylibrarian
 import collections
 


### PR DESCRIPTION
Wasn't referring to provided lib/feedparser