### PR TITLE
Reworked library scan and language lookups

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -466,6 +466,11 @@
                   <br>
                   <i class="smalltext">This will auto add new authors from GoodReads</i>
                   </div>
+		  <div>
+                  <label>One book per directory:</label><input type="checkbox" name="imp_singlebook" value=1 ${config['imp_singlebook']} />
+                  <br>
+                  <i class="smalltext">This imports one book per directory, tick this if you keep multiple formats of the same book in the same directory</i>
+                  </div>
 
 		</td>
                 <td>

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -79,6 +79,7 @@ DOWNLOAD_DIR = None
 
 IMP_PREFLANG = None
 IMP_ONLYISBN = False
+IMP_SINGLEBOOK = True
 IMP_AUTOADD = None
 
 BOOK_API = None
@@ -145,8 +146,8 @@ VERSIONCHECK_INTERVAL = 24 #Every 2 hours
 SEARCH_INTERVAL = 720 #Every 12 hours
 SCAN_INTERVAL = 10 #Every 10 minutes
 FULL_SCAN = 0 #full scan would remove books from db
-NOTFOUND_STATUS = 'Skipped' #value to marke missing books in db, can be 'Open', 'Ignored',' 'Wanted','Skipped'
 ADD_AUTHOR = 1 #auto add authors not found in db from goodreads
+NOTFOUND_STATUS = 'Skipped' #value to mark missing books in db, can be 'Open', 'Ignored',' 'Wanted','Skipped'
 
 EBOOK_DEST_FOLDER = None
 EBOOK_DEST_FILE = None
@@ -266,7 +267,7 @@ def initialize():
 
         global __INITIALIZED__, FULL_PATH, PROG_DIR, LOGLEVEL, DAEMON, DATADIR, CONFIGFILE, CFG, LOGDIR, HTTP_HOST, HTTP_PORT, HTTP_USER, HTTP_PASS, HTTP_ROOT, HTTP_LOOK, LAUNCH_BROWSER, LOGDIR, CACHEDIR, MATCH_RATIO, \
 	    PROXY_HOST, PROXY_TYPE, \
-            IMP_ONLYISBN, IMP_PREFLANG, IMP_AUTOADD, SAB_HOST, SAB_PORT, SAB_SUBDIR, SAB_API, SAB_USER, SAB_PASS, DESTINATION_DIR, DESTINATION_COPY, DOWNLOAD_DIR, SAB_CAT, USENET_RETENTION, NZB_BLACKHOLEDIR, GR_API, GB_API, BOOK_API, \
+            IMP_ONLYISBN, IMP_SINGLEBOOK, IMP_PREFLANG, IMP_AUTOADD, SAB_HOST, SAB_PORT, SAB_SUBDIR, SAB_API, SAB_USER, SAB_PASS, DESTINATION_DIR, DESTINATION_COPY, DOWNLOAD_DIR, SAB_CAT, USENET_RETENTION, NZB_BLACKHOLEDIR, GR_API, GB_API, BOOK_API, \
             NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, NZB_DOWNLOADER_NZBGET, \
             NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, NEWZNAB, NEWZNAB_HOST, NEWZNAB_API, NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, NEWZNAB2, NEWZNAB_HOST2, NEWZNAB_API2, EBOOK_TYPE, KAT, USENETCRAWLER, USENETCRAWLER_HOST, USENETCRAWLER_API, \
             VERSIONCHECK_INTERVAL, SEARCH_INTERVAL, SCAN_INTERVAL, EBOOK_DEST_FOLDER, EBOOK_DEST_FILE, MAG_DEST_FOLDER, MAG_DEST_FILE, USE_TWITTER, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
@@ -275,7 +276,7 @@ def initialize():
             USE_PUSHOVER, PUSHOVER_ONSNATCH, PUSHOVER_KEYS, PUSHOVER_APITOKEN, PUSHOVER_PRIORITY, PUSHOVER_ONDOWNLOAD, \
             TOR_DOWNLOADER_TRANSMISSION, TRANSMISSION_HOST, TRANSMISSION_PASS, TRANSMISSION_USER, \
             TOR_DOWNLOADER_DELUGE, DELUGE_HOST, DELUGE_USER, DELUGE_PASS, DELUGE_PORT, \
-	    NOTFOUND_STATUS, FULL_SCAN, ADD_AUTHOR, NMA_ENABLED, NMA_APIKEY, NMA_PRIORITY, NMA_ONSNATCH, \
+	    FULL_SCAN, ADD_AUTHOR, NOTFOUND_STATUS, NMA_ENABLED, NMA_APIKEY, NMA_PRIORITY, NMA_ONSNATCH, \
             GIT_USER, GIT_REPO, GIT_BRANCH, INSTALL_TYPE, CURRENT_VERSION, LATEST_VERSION, COMMITS_BEHIND, NUMBEROFSEEDERS
 
         if __INITIALIZED__:
@@ -339,7 +340,8 @@ def initialize():
         #TODO - investigate this for future users
         #Something funny here - putting IMP_AUTOADD after IMP_ONLYISBN resulted in it not working
         #Couldn't see it
-            
+        IMP_SINGLEBOOK = bool(check_setting_int(CFG, 'General', 'imp_singlebook', 0))
+           
         GIT_USER = check_setting_str(CFG, 'Git', 'git_user', 'dobytang')
         GIT_REPO = check_setting_str(CFG, 'Git', 'git_repo', 'lazylibrarian')
         GIT_BRANCH = check_setting_str(CFG, 'Git', 'git_branch', 'master')
@@ -423,9 +425,9 @@ def initialize():
         VERSIONCHECK_INTERVAL = int(check_setting_str(CFG, 'SearchScan', 'versioncheck_interval', '24'))
 
         FULL_SCAN = bool(check_setting_int(CFG, 'LibraryScan', 'full_scan', 0))
+	ADD_AUTHOR = bool(check_setting_int(CFG, 'LibraryScan', 'add_author', 1))
 	NOTFOUND_STATUS = check_setting_str(CFG, 'LibraryScan', 'notfound_status','Skipped')
-	ADD_AUTHOR = bool(check_setting_int(CFG, 'LibraryScan', 'add_author', 0))
-
+	
         EBOOK_DEST_FOLDER = check_setting_str(CFG, 'PostProcess', 'ebook_dest_folder', '$Author/$Title')
         EBOOK_DEST_FILE = check_setting_str(CFG, 'PostProcess', 'ebook_dest_file', '$Title - $Author')
         MAG_DEST_FOLDER = check_setting_str(CFG, 'PostProcess', 'mag_dest_folder', '_Magazines/$Title/$IssueDate')
@@ -551,6 +553,7 @@ def config_write():
     new_config['General']['match_ratio'] = MATCH_RATIO
 
     new_config['General']['imp_onlyisbn'] = int(IMP_ONLYISBN)
+    new_config['General']['imp_singlebook'] = int(IMP_SINGLEBOOK)
     new_config['General']['imp_preflang'] = IMP_PREFLANG
     new_config['General']['imp_autoadd'] =  IMP_AUTOADD
 
@@ -661,9 +664,9 @@ def config_write():
 
     new_config['LibraryScan'] = {}
     new_config['LibraryScan']['full_scan'] = FULL_SCAN
-    new_config['LibraryScan']['notfound_status'] = NOTFOUND_STATUS
     new_config['LibraryScan']['add_author'] = ADD_AUTHOR
-
+    new_config['LibraryScan']['notfound_status'] = NOTFOUND_STATUS
+    
     new_config['PostProcess'] = {}
     new_config['PostProcess']['ebook_dest_folder'] = EBOOK_DEST_FOLDER
     new_config['PostProcess']['ebook_dest_file'] = EBOOK_DEST_FILE
@@ -715,7 +718,8 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS books (AuthorID TEXT, AuthorName TEXT, AuthorLink TEXT, BookName TEXT, BookSub TEXT, BookDesc TEXT, BookGenre TEXT, BookIsbn TEXT, BookPub TEXT, BookRate INTEGER, BookImg TEXT, BookPages INTEGER, BookLink TEXT, BookID TEXT UNIQUE, BookDate TEXT, BookLang TEXT, BookAdded TEXT, Status TEXT, Series TEXT, SeriesOrder INTEGER)')
     c.execute('CREATE TABLE IF NOT EXISTS wanted (BookID TEXT, NZBurl TEXT, NZBtitle TEXT, NZBdate TEXT, NZBprov TEXT, Status TEXT, NZBsize TEXT, AuxInfo TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS magazines (Title TEXT, Frequency TEXT, Regex TEXT, Status TEXT, MagazineAdded TEXT, LastAcquired TEXT, IssueDate TEXT, IssueStatus TEXT)')
-
+    c.execute('CREATE TABLE IF NOT EXISTS languages ( isbn TEXT, lang TEXT )')
+	
     try:
         logger.info('Checking database')
         c.execute('SELECT BookSub from books')

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -12,6 +12,7 @@ import lib.fuzzywuzzy as fuzzywuzzy
 from lib.fuzzywuzzy import fuzz, process
 
 import time
+import unidecode
 
 class GoodReads:
 	# http://www.goodreads.com/api/
@@ -25,6 +26,7 @@ class GoodReads:
 		threading.currentThread().name = "GR-SEARCH"
 		resultlist = []
 		api_hits = 0
+		
 		url = urllib.quote_plus(authorname.encode('utf-8'))
 		set_url = 'http://www.goodreads.com/search.xml?q=' + url + '&' + urllib.urlencode(self.params)
 		logger.info('Now searching GoodReads API with keyword: ' + authorname)
@@ -60,7 +62,7 @@ class GoodReads:
 				authorNameResult = author.find('./best_book/author/name').text
 				booksub = ""
 				bookpub = ""
-				booklang = "en"
+				booklang = "Unknown" 
 
 				try:
 					bookimg = author.find('./best_book/image_url').text
@@ -132,16 +134,19 @@ class GoodReads:
 			else:
 				logger.info('An unexpected error has occurred when searching for an author')
 
-		logger.info('Found %s results with keyword: %s' % (resultcount, authorname))
-		logger.info('The GoodReads API was hit %s times for keyword %s' % (str(api_hits), authorname))
+		logger.debug('Found %s results with keyword: %s' % (resultcount, authorname))
+		logger.debug('The GoodReads API was hit %s times for keyword %s' % (str(api_hits), authorname))
 
 		queue.put(resultlist)
 
 	def find_author_id(self):
-
-		URL = 'http://www.goodreads.com/api/author_url/' + urllib.quote(self.name) + '?' + urllib.urlencode(self.params)
-		logger.debug("Searching for author with name: %s" % self.name)
-
+		author = self.name
+		author = author.replace('. ',' ')
+		author = author.replace('.',' ')
+		author = author.replace('  ',' ')
+		URL = 'http://www.goodreads.com/api/author_url/' + urllib.quote(author) + '?' + urllib.urlencode(self.params)
+		logger.debug("Searching for author with name: %s" % author)
+		
 		# Cache our request
 		request = urllib2.Request(URL)
 		if lazylibrarian.PROXY_HOST:
@@ -158,17 +163,19 @@ class GoodReads:
 		rootxml = sourcexml.getroot()
 		resultxml = rootxml.getiterator('author')
 		authorlist = []
-
-		if not len(rootxml):
+	
+		if not len(resultxml):
 			logger.info('No authors found with name: %s' % self.name)
-			return authorlist
 		else:
+			# In spite of how this looks, goodreads only returns one result, even if there are multiple matches
+			# we just have to hope we get the right one. eg search for "James Lovelock" returns "James E. Lovelock"
+			# who only has one book listed under googlebooks, the rest are under "James Lovelock"
+			# goodreads has all his books under "James E. Lovelock". Can't come up with a good solution yet. 
+			# For now we'll have to let the user handle this by selecting/adding the author manually 
 			for author in resultxml:
 				authorid = author.attrib.get("id")
 				authorname = author[0].text
-				logger.info('Found author: %s with GoodReads-id: %s' % (authorname, authorid))
-
-			authorlist = self.get_author_info(authorid, authorname)
+				authorlist = self.get_author_info(authorid, authorname)
 
 		return authorlist
 
@@ -192,25 +199,32 @@ class GoodReads:
 		except Exception, e:
 			logger.error("Error fetching author ID: " + str(e))
 
-		if not len(rootxml):
+		if not len(resultxml):
 			logger.info('No author found with ID: ' + authorid)
 
 		else:
 			logger.info("[%s] Processing info for authorID: %s" % (authorname, authorid))
 
+			# PAB added authorname to author_dict - this holds the intact name preferred by GR
 			author_dict = {
 				'authorid':   resultxml[0].text,
 				'authorlink':   resultxml.find('link').text,
 				'authorimg':  resultxml.find('image_url').text,
 				'authorborn':   resultxml.find('born_at').text,
 				'authordeath':  resultxml.find('died_at').text,
-				'totalbooks':   resultxml.find('works_count').text
+				'totalbooks':   resultxml.find('works_count').text,
+				'authorname':   authorname
 				}
 		return author_dict
 
 	def get_author_books(self, authorid=None, authorname=None, refresh=False):
-
+		
 		api_hits = 0
+		gr_lang_hits = 0
+		lt_lang_hits = 0
+		gb_lang_change = 0
+		cache_hits = 0
+		not_cached = 0
 		URL = 'http://www.goodreads.com/author/list/' + authorid + '.xml?' + urllib.urlencode(self.params)
 
 		#Artist is loading
@@ -235,8 +249,9 @@ class GoodReads:
 		rootxml = sourcexml.getroot()
 		resultxml = rootxml.getiterator('book')
 		books_dict = []
-
-		if not len(rootxml):
+		valid_langs = ([valid_lang.strip() for valid_lang in lazylibrarian.IMP_PREFLANG.split(',')])
+					
+		if not len(resultxml):
 			logger.info('[%s] No books found for author with ID: %s' % (authorname, authorid))
 
 		else:
@@ -256,7 +271,6 @@ class GoodReads:
 			loopCount = 1;
 			
 			while (len(resultxml)):
-				
 				for book in resultxml:
 					total_count = total_count + 1
 
@@ -274,47 +288,117 @@ class GoodReads:
 					except AttributeError:
 						bookimg = 'images/nocover.png'
 
+					
+# PAB this next section tries to get the book language using the isbn13 to look it up. If no isbn13 we skip the book entirely, rather than 
+# including it with an "Unknown" language. Changed this so we can still include the book with language set to "Unknown"
+# There is a setting in config.ini to allow or skip books with "Unknown" language if you really don't want to include them.
+# Not all GR books have isbn13 filled in, but all have a GR bookid, which we've already got, so use that.
+# Also, with GR API rules we can only call the API once per second, which slows us down a lot when all we want is to get the language.
+# We sleep for one second per book that GR knows about for each author you have in your library.
+# The libraryThing API has the same 1 second restriction, and is limited to 1000 hits per day, but has fewer books with unknown language
+# To get around this and speed up the process, see if we already have a book in the database with a similar start to the ISBN.
+# The way ISBNs work, digits 3-5 of a 13 char ISBN or digits 0-2 of a 10 digit ISBN indicate the region/language 
+# so if two books have the same 3 digit isbn code, they _should_ be the same language.
+# I ran a simple python script on my library of 1500 books, and these codes were 100% correct on matching book languages, no mis-matches.
+# It did result in a small number of books with "unknown" language being wrongly matched, but most "unknown" were matched to the correct language. 
+# We could look up ISBNs we already know about in the database, but this only holds books in the languages we want to keep, which reduces the number of
+# cache hits, so we create a new database table, holding ALL results including the ISBNs for languages we don't want and books we reject.
+# The new table is created (if not exists) in init.py so by the time we get here there is an existing table. 
+# 
+# If we haven't an already matching partial ISBN, look up language code from libraryThing  "http://www.librarything.com/api/thingLang.php?isbn=1234567890"
+# If you find a matching language, add it to the database.  If "unknown" or "invalid", try GR as maybe GR can provide a match.
+# If both LT and GR return unknown, add isbn to db as "unknown". No point in repeatedly asking LT for a code it's told you it doesn't know.
+#
+# As an extra option, if language includes "All" in config.ini, we can skip this whole section and process everything much faster by not querying for language at all.
+# It does mean we include a lot of unwanted foreign translations in the database, but it's _much_ faster.
+#
 					bookLanguage = "Unknown"
-
-					try:
-						time.sleep(1) #sleep 1 second to respect goodreads api terms
-
-						if (book.find('isbn13').text is not None):
-							BOOK_URL = 'http://www.goodreads.com/book/isbn?isbn=' + book.find('isbn13').text + '&' + urllib.urlencode(self.params) 
-
-							logger.debug(u"Book URL: " + str(BOOK_URL))
+					find_field="id"
+					isbn=""
+					isbnhead=""
+					if "All" not in valid_langs: # do we care about language
+						if (book.find('isbn').text is not None):
+							find_field="isbn"
+							isbn=book.find('isbn').text
+							isbnhead=isbn[0:3]
+					    	else:
+							if (book.find('isbn13').text is not None):
+						    		find_field="isbn13"
+						    		isbn=book.find('isbn13').text
+						    		isbnhead=isbn[3:6]
+					    	if (find_field != 'id'): # isbn or isbn13 found
 							
-							try:
-								# Cache our request
-								request = urllib2.Request(BOOK_URL)
-								if lazylibrarian.PROXY_HOST:
-									request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
-								request.add_header('User-Agent', USER_AGENT)
-								opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
-								resp = opener.open(request)
-							except Exception, e:
-								logger.error("Error finding results: ", e)
+							match = myDB.action('SELECT lang FROM languages where isbn = "%s"' % (isbnhead)).fetchone()
+					        	if (match):
+						    		bookLanguage=match['lang']
+								cache_hits = cache_hits + 1
+				    				logger.debug("Found cached language [%s] for %s [%s]" % (bookLanguage, find_field, isbnhead))
+							else:
+								# no match in cache, try searching librarything for a language code using the isbn
+								# if no language found, librarything return value is "invalid" or "unknown"
+								# returns plain text, not xml
+ 								BOOK_URL = 'http://www.librarything.com/api/thingLang.php?isbn=' + isbn
+ 								try:
+									time.sleep(1) #sleep 1 second to respect librarything api terms
+									resp = urllib2.urlopen(BOOK_URL, timeout=30).read()
+                        						lt_lang_hits = lt_lang_hits + 1
+									logger.debug("LibraryThing reports language [%s] for %s" % (resp, isbnhead))
+									
+									if (resp == 'invalid' or resp == 'unknown'):
+										find_field="id" # reset the field to force search on goodreads	
+									else:
+										bookLanguage=resp # found a language code
+										myDB.action('insert into languages values ("%s", "%s")' % (isbnhead, bookLanguage))
+										logger.debug(u"LT language: " + str(bookLanguage))
+								except Exception, e:
+									find_field="id" # reset the field to search on goodreads
+					    				logger.error("Error finding results: ", e)
+							
+						if (find_field == 'id'): # [or bookLanguage == "Unknown"] no earlier match, we'll have to search the goodreads api
+					    		try:
+						   		if (book.find(find_field).text is not None):
+									BOOK_URL = 'http://www.goodreads.com/book/show?id=' + book.find(find_field).text + '&' + urllib.urlencode(self.params) 
+									logger.debug(u"Book URL: " + str(BOOK_URL))
+							
+									try:
+										# Cache our request
+										if (isbnhead == ""): # no isbn found, so we didn't try librarything
+											time.sleep(1) # only sleep for GR API if we didn't sleep for librarything
+										request = urllib2.Request(BOOK_URL)
+										if lazylibrarian.PROXY_HOST:
+											request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
+										request.add_header('User-Agent', USER_AGENT)
+										opener = urllib2.build_opener(SimpleCache.CacheHandler(".AuthorCache"), SimpleCache.ThrottlingProcessor(5))
+										resp = opener.open(request)
+										gr_lang_hits = gr_lang_hits + 1
+									except Exception, e:
+										logger.error("Error finding results: ", e)
 
-							BOOK_sourcexml = ElementTree.parse(resp)
-							BOOK_rootxml = BOOK_sourcexml.getroot()
+									BOOK_sourcexml = ElementTree.parse(resp)
+									BOOK_rootxml = BOOK_sourcexml.getroot()
 
-							bookLanguage = BOOK_rootxml.find('./book/language_code').text
+									bookLanguage = BOOK_rootxml.find('./book/language_code').text
+									if not bookLanguage:
+										bookLanguage = "Unknown"
+									
+									if (isbnhead != ""): # GR didn't give an isbn so we can't cache it, just use for this book
+										myDB.action('insert into languages values ("%s", "%s")' % (isbnhead, bookLanguage))
+										logger.debug("GoodReads reports language [%s] for %s" % (bookLanguage, isbnhead))
+									else:
+										not_cached = not_cached + 1
 
-							logger.debug(u"language: " + str(bookLanguage))
-						else:
-							logger.debug("No ISBN provided, skipping")
+									logger.debug(u"GR language: " + str(bookLanguage))
+						   		else:
+									logger.debug("No %s provided for [%s]" % (find_field, book.find('title').text))
+									#continue
+
+					  		except Exception, e:
+								logger.debug(u"An error has occured: " + str(e))
+			
+						if bookLanguage not in valid_langs:
+							logger.debug('Skipped a book with language %s' % bookLanguage)
+							ignored = ignored + 1
 							continue
-
-					except Exception, e:
-						logger.debug(u"An error has occured: " + str(e))
-
-					if not bookLanguage:
-						bookLanguage = "Unknown"
-					valid_langs = ([valid_lang.strip() for valid_lang in lazylibrarian.IMP_PREFLANG.split(',')])
-					if bookLanguage not in valid_langs:
-						logger.debug('Skipped a book with language %s' % bookLanguage)
-						ignored = ignored + 1
-						continue
 
 					bookname = book.find('title').text
 					bookid = book.find('id').text
@@ -343,8 +427,12 @@ class GoodReads:
 							book_status = resulted['Status']
 					else:
 						book_status = "Skipped"
+
+    					bookname = bookname.replace(':','')
+					bookname = unidecode.unidecode(u'%s' % bookname)
+					bookname = bookname.strip() # strip whitespace
 					
-					if not (re.match('[^\w-]', bookname)): #remove books with bad caracters in title
+					if not (re.match('[^\w-]', bookname)): #remove books with bad characters in title
 						if book_status != "Ignored":
 							controlValueDict = {"BookID": bookid}
 							newValueDict = {
@@ -382,6 +470,7 @@ class GoodReads:
 						else:
 							book_ignore_count = book_ignore_count + 1
 					else:
+						logger.debug(u"removed result [" + bookname + "] for bad characters")
 						removedResults = removedResults + 1
 
 				loopCount = loopCount + 1
@@ -403,8 +492,7 @@ class GoodReads:
 				rootxml = sourcexml.getroot()
 				resultxml = rootxml.getiterator('book')
 
-		logger.info('[%s] The GoodReads API was hit %s times to populate book list' % (authorname, str(api_hits)))
-		
+
 		lastbook = myDB.action("SELECT BookName, BookLink, BookDate from books WHERE AuthorID='%s' AND Status != 'Ignored' order by BookDate DESC" % authorid).fetchone()
 		if lastbook:
                         lastbookname = lastbook['BookName']
@@ -417,7 +505,7 @@ class GoodReads:
                         
 		unignoredbooks = myDB.select("SELECT COUNT(BookName) as unignored FROM books WHERE AuthorID='%s' AND Status != 'Ignored'" % authorid)
 		bookCount = myDB.select("SELECT COUNT(BookName) as counter FROM books WHERE AuthorID='%s'" % authorid)   
-
+		
 		controlValueDict = {"AuthorID": authorid}
 		newValueDict = {
 				"Status": "Active",
@@ -437,10 +525,14 @@ class GoodReads:
 		logger.debug("Removed %s bad character results for author" % removedResults)
 		logger.debug("Ignored %s books by author marked as Ignored" % book_ignore_count)
 		logger.debug("Imported/Updated %s books for author" % modified_count)
+		
+		myDB.action('insert into stats values ("%s", %i, %i, %i, %i, %i, %i, %i, %i)' % (authorname, api_hits, gr_lang_hits, lt_lang_hits, gb_lang_change, cache_hits, ignored, removedResults, not_cached))
+
 		if refresh:
 			logger.info("[%s] Book processing complete: Added %s books / Updated %s books" % (authorname, str(added_count), str(updated_count)))
 		else:
 			logger.info("[%s] Book processing complete: Added %s books to the database" % (authorname, str(added_count)))
+		
 		return books_dict
 
 	def find_book(self, bookid=None, queue=None):
@@ -464,12 +556,16 @@ class GoodReads:
 		rootxml = sourcexml.getroot()
 
 		bookLanguage = rootxml.find('./book/language_code').text
-
+		bookname = rootxml.find('./book/title').text
+		
 		if not bookLanguage:
 			bookLanguage = "Unknown"
+#
+## PAB user has said they want this book, don't block for bad language, just warn
+#
 		valid_langs = ([valid_lang.strip() for valid_lang in lazylibrarian.IMP_PREFLANG.split(',')])
 		if bookLanguage not in valid_langs:
-			logger.debug('Skipped a book with language %s' % bookLanguage)
+			logger.info('Book %s language does not match preference' % bookname)
 
 		if (rootxml.find('./book/publication_year').text == None):
 			bookdate = "0000"
@@ -486,7 +582,6 @@ class GoodReads:
 			bookimg = 'images/nocover.png'
 
 		authorname = rootxml.find('./book/authors/author/name').text
-		bookname = rootxml.find('./book/title').text
 		bookdesc = rootxml.find('./book/description').text
 		bookisbn = rootxml.find('./book/isbn').text
 		bookpub = rootxml.find('./book/publisher').text

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -1,16 +1,154 @@
 import os
 import glob
-import re
+import re, time
 import lazylibrarian
 import shlex
 from lazylibrarian import logger, database, importer
 from lazylibrarian.gr import GoodReads
+import lib.fuzzywuzzy as fuzzywuzzy
+from lib.fuzzywuzzy import fuzz, process
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, SubElement
+import zipfile 
+from lxml import etree
+from mobi import Mobi 
+
+def get_book_info(fname):
+    # only handles epub, mobi and opf for now, 
+    # for pdf see below
+    words = fname.split('.')
+    extn = words[len(words)-1]
+
+    if (extn == "mobi"):
+	book = Mobi(fname)
+	book.parse()
+	res = {}
+	res['creator'] = book.author()
+	res['title'] =  book.title()
+	res['language'] = book.language()
+	res['isbn'] = book.isbn()
+        return res
+
+    ns = {
+        'n':'urn:oasis:names:tc:opendocument:xmlns:container',
+        'pkg':'http://www.idpf.org/2007/opf',
+        'dc':'http://purl.org/dc/elements/1.1/'
+    }
+    # none of the pdfs in my library had language,isbn
+    # most didn't have author, or had the wrong author
+    # (author set to publisher, or software used)
+    # so probably not much point in looking at pdfs
+    # 
+    #if (extn == "pdf"):
+    #	  pdf = PdfFileReader(open(fname, "rb"))
+    #	  txt = pdf.getDocumentInfo()
+	  # repackage the data here to get components we need
+    #     res = {}
+    #     for s in ['title','language','creator','isbn']:
+    #         res[s] = txt[s]
+    #	  return res
+
+    if (extn == "epub"):	
+      # prepare to read from the .epub file
+      zip = zipfile.ZipFile(fname)
+      # find the contents metafile
+      txt = zip.read('META-INF/container.xml')	
+      tree = etree.fromstring(txt)
+      cfname = tree.xpath('n:rootfiles/n:rootfile/@full-path',namespaces=ns)[0]
+      # grab the metadata block from the contents metafile		
+      txt = zip.read(cfname)			
+      tree = etree.fromstring(txt)
+    else:
+      if (extn == "opf"):
+	txt = open(fname).read()
+        tree = etree.fromstring(txt)
+      else:
+        return ""
+					
+    p = tree.xpath('/pkg:package/pkg:metadata',namespaces=ns)[0]
+    # repackage the data - not too happy with this as there can be
+    # several "identifier", only one of which is an isbn, how can we tell?
+    # I just strip formatting, check for length, and check is only digits 
+    # except the last digit of an isbn10 may be 'X'
+    res = {}
+    for s in ['title','language','creator']:
+        res[s] = p.xpath('dc:%s/text()'%(s),namespaces=ns)[0]
+	s='identifier'
+	isbn=""
+        for i in p.xpath('dc:identifier/text()',namespaces=ns):
+		i = re.sub('[- ]', '', i)
+		if len(i) == 13:
+		    if i.isdigit():
+			isbn = i
+		elif len(i) == 10:
+			if i[:8].isdigit():
+				isbn = i
+	res[s] = isbn
+    return res
 
 def getList(st):
         my_splitter = shlex.shlex(st, posix=True)
         my_splitter.whitespace += ','
         my_splitter.whitespace_split = True
 	return list(my_splitter)
+
+##PAB fuzzy search for book in library, return LL bookid if found or zero if not, return bookid to more easily update status 
+def find_book_in_db(myDB,author,book):
+   	# prefer an exact match on author & book
+        match = myDB.action("SELECT BookID FROM books where AuthorName=? and BookName=?",[author,book]).fetchone()
+    	if match:
+		logger.debug('Exact match [%s]' % book)
+      		return match['BookID']
+    	else:
+		# No exact match
+		# Try a more complex fuzzy match against each book in the db by this author
+		# Using hard-coded ratios for now, ratio high (>90), partial_ratio lower (>65)
+		# These are results that work well on my library, minimal false matches and no misses on books that should be matched
+		# Maybe make ratios configurable in config.ini later
+# 
+		books = myDB.select('SELECT BookID,BookName FROM books where AuthorName="%s"' % author)
+		best_ratio = 0
+		best_partial = 0
+		ratio_name = ""
+		partial_name = ""
+		ratio_id = 0
+		partial_id = 0
+		logger.debug("Found %s books for %s" % (len(books),author))
+		for a_book in books:
+			# lowercase everything to raise fuzziness scores
+			book_lower = book.lower()
+			a_book_lower = a_book['BookName'].lower()
+			#
+			ratio = fuzz.ratio(book_lower, a_book_lower)
+			partial = fuzz.partial_ratio(book_lower, a_book_lower)
+		       	if ratio > best_ratio:
+				best_ratio = ratio
+				ratio_name = a_book['BookName']
+				ratio_id = a_book['BookID']
+			if partial > best_partial:
+				best_partial = partial
+				partial_name = a_book['BookName']
+				partial_id = a_book['BookID']
+			
+			else:
+		 		if partial == best_partial:
+					# prefer the match closest to the left, ie prefer starting with a match and ignoring the rest
+					# this eliminates most false matches against omnibuses
+					if a_book_lower.find(book_lower) < partial_name.lower().find(book_lower):
+						logger.debug("Fuzz left prefer [%s] over [%s]" % (a_book['BookName'], partial_name))
+						best_partial = partial
+						partial_name = a_book['BookName']
+						partial_id = a_book['BookID']
+			#		
+		if best_ratio > 90:
+			logger.debug("Fuzz match   ratio [%d] [%s] [%s]" % (best_ratio, book, ratio_name))
+			return(ratio_id)
+		if best_partial > 65:	
+			logger.debug("Fuzz match partial [%d] [%s] [%s]" % (best_partial, book, partial_name))
+			return(partial_id)
+	
+		logger.debug('Fuzz failed [%s - %s] ratio [%d,%s], partial [%d,%s]' % (author, book, best_ratio, ratio_name, best_partial, partial_name))	
+		return 0
 
 def LibraryScan(dir=None):
 	if not dir:
@@ -24,8 +162,12 @@ def LibraryScan(dir=None):
 		return
 	
 	myDB = database.DBConnection()
-	new_authors = []
+	
+	myDB.action('drop table if exists stats')
+	myDB.action('create table stats ( authorname text, GR_book_hits int, GR_lang_hits int, LT_lang_hits int, GB_lang_change, cache_hits int, bad_lang int, bad_char int, uncached int )')
 
+	new_authors = []
+	
 	logger.info('Scanning ebook directory: %s' % dir.decode(lazylibrarian.SYS_ENCODING, 'replace'))
 
 	book_list = []
@@ -55,7 +197,27 @@ def LibraryScan(dir=None):
 				if bookAuthor not in new_authors:
 					new_authors.append(bookAuthor)
 
-	latest_subdirectory = []
+	# guess this was meant to save repeat-scans of the same directory
+	# if it contains multiple formats of the same book, but there was no code
+	# that looked at the array. renamed from latest to processed to make purpose clearer
+	processed_subdirectories = [] 
+
+	matchString = ''
+        for char in lazylibrarian.EBOOK_DEST_FILE:
+                matchString = matchString + '\\' + char
+        #massage the EBOOK_DEST_FILE config parameter into something we can use with regular expression matching
+        booktypes = ''
+        count=-1;
+        booktype_list =  getList(lazylibrarian.EBOOK_TYPE)
+        for book_type in booktype_list:
+              count+=1
+              if count == 0:
+                       booktypes = book_type
+              else:
+                       booktypes = booktypes + '|'+book_type
+        matchString = matchString.replace("\\$\\A\\u\\t\\h\\o\\r", "(?P<author>.*?)").replace("\\$\\T\\i\\t\\l\\e","(?P<book>.*?)")+'\.['+booktypes+']'
+        pattern = re.compile(matchString, re.VERBOSE)
+                               
 	for r,d,f in os.walk(dir):
 		for directory in d[:]:
 			if directory.startswith("."):
@@ -64,84 +226,193 @@ def LibraryScan(dir=None):
 			if directory.startswith("_"):
 				d.remove(directory)
 		for files in f:
-			 subdirectory = r.replace(dir,'')
-			 latest_subdirectory.append(subdirectory)
-			 logger.info("[%s] Now scanning subdirectory %s" % (dir.decode(lazylibrarian.SYS_ENCODING, 'replace'), subdirectory.decode(lazylibrarian.SYS_ENCODING, 'replace')))
-			 matchString = ''
-			 for char in lazylibrarian.EBOOK_DEST_FILE:
-				matchString = matchString + '\\' + char
-			 #massage the EBOOK_DEST_FILE config parameter into something we can use with regular expression matching
-			 booktypes = ''
-			 count=-1;
-			 booktype_list =  getList(lazylibrarian.EBOOK_TYPE)
-			 for book_type in booktype_list:
-			 	count+=1
-				if count == 0:
-					booktypes = book_type
+		    file_count += 1 
+		    subdirectory = r.replace(dir,'')
+		    # Added new code to skip if we've done this directory before. Made this conditional with a switch in config.ini
+		    # in case user keeps multiple different books in the same subdirectory
+		    if (lazylibrarian.IMP_SINGLEBOOK) and (subdirectory in processed_subdirectories):
+		        logger.debug("[%s] already scanned" % subdirectory)
+                    else:
+			logger.info("[%s] Now scanning subdirectory %s" % (dir.decode(lazylibrarian.SYS_ENCODING, 'replace'), subdirectory.decode(lazylibrarian.SYS_ENCODING, 'replace')))
+						 
+# 			If this is a book, try to get author/title/isbn/language
+# 			If metadata.opf exists, use that
+# 			else if epub or mobi, read metadata from the book
+# 			else have to try pattern match for author/title	and look up isbn/lang from LT or GR later
+#
+#			Is it a book (extension found in booktypes)
+			match = 0
+			words = files.split('.')
+			extn = words[len(words)-1]
+			if (extn in booktypes):
+ 				# see if there is a metadata file in this folder with the info we need
+				try:
+					metafile = r + "/metadata.opf"
+					res = get_book_info(metafile)
+					if res:
+						book = res['title']
+						author = res['creator']
+						language = res['language']
+						isbn = res['identifier']
+						match = 1
+						logger.debug("file meta [%s] [%s] [%s] [%s]" % (isbn,language,author,book))
+					
+				except:	
+					logger.debug("No metadata file in %s" % r)
+				
+				if not match:
+					# it's a book, but no external metadata found
+					# if it's an epub or a mobi we can try to read metadata from it
+					if (extn == "epub") or (extn == "mobi"):
+						book_file = r + "/" + files
+						res = get_book_info(book_file)
+						if res:
+							book = res['title']
+							author = res['creator']
+							language = res['language']
+							isbn = res['identifier']
+							match = 1
+							logger.debug("book meta [%s] [%s] [%s] [%s]" % (isbn,language,author,book))
+						
+			if not match:
+				match = pattern.match(files)
+				if match:
+					author = match.group("author")
+					book = match.group("book")
 				else:
-					booktypes = booktypes + '|'+book_type
-			 matchString = matchString.replace("\\$\\A\\u\\t\\h\\o\\r", "(?P<author>.*?)").replace("\\$\\T\\i\\t\\l\\e","(?P<book>.*?)")+'\.['+booktypes+']'
-			 #pattern = re.compile(r'(?P<author>.*?)\s\-\s(?P<book>.*?)\.(?P<format>.*?)', re.VERBOSE)
-			 pattern = re.compile(matchString, re.VERBOSE)
-			 match = pattern.match(files)
-			 if match:
-				author = match.group("author")
-				book = match.group("book")
-			 	#check if book is in database, and not marked as in library
-				check_exist_book = myDB.action("SELECT * FROM books where AuthorName=? and BookName=? and Status!=?",[author,book,'Open']).fetchone()
-				if not check_exist_book:
-					check_exist_author = myDB.action("SELECT * FROM authors where AuthorName=?",[author]).fetchone()
-					if not check_exist_author and lazylibrarian.ADD_AUTHOR:
-						GR = GoodReads(author)
-						try:
-							author_gr = GR.find_author_id()
-						except:
-							continue
-						#only try to add if GR data matches found author data
-						if author_gr:
-							authorid = author_gr['authorid']
-							authorlink  = author_gr['authorlink']
-							pageIdx = authorlink.rfind('/')
-							authorlink  = authorlink[pageIdx+1:]
-							#match_auth = authorid+"."+author.replace('. ','_')
-							#Original Line does not allow author match.
-							match_auth = author.replace('.','_')
-                                                        match_auth = match_auth.replace(' ','_')
-                                                        match_auth = match_auth.replace('__','_')
-                                                        match_auth = authorid+"."+match_auth
-							# Hopefully someone can come up with a more efficient way of doing this.
-							logger.debug(match_auth)
-							logger.debug(authorlink)
-							if match_auth == authorlink:
-								logger.info("Adding %s" % author)
+					logger.debug("Pattern match failed [%s]" % files)
+				
+			else:
+			 	processed_subdirectories.append(subdirectory) # flag that we found a book in this subdirectory
+				# 
+				# If we have a valid looking isbn, and language != "Unknown", add it to cache
+				#
+				if not language:
+					language = "Unknown"
+
+				# strip any formatting from the isbn
+				isbn = re.sub('[- ]', '', isbn)
+				if len(isbn) != 10 and len(isbn) != 13:
+					isbn=""
+				if not isbn.isdigit():
+					isbn=""
+				if (isbn != "" and language != "Unknown"):
+					logger.debug("Found Language [%s] ISBN [%s]" % (language, isbn)) 
+					# we need to add it to language cache if not already there
+					if len(isbn) == 10:
+						isbnhead=isbn[0:3]
+					else:
+						isbnhead=isbn[3:6]
+					match = myDB.action('SELECT lang FROM languages where isbn = "%s"' % (isbnhead)).fetchone()
+					if not match:
+						myDB.action('insert into languages values ("%s", "%s")' % (isbnhead, language))
+						logger.debug("Cached Lang [%s] ISBN [%s]" % (language, isbnhead)) 
+					else:
+						logger.debug("Already cached Lang [%s] ISBN [%s]" % (language, isbnhead)) 
+				
+						    	
+				# get authors name in a consistent format
+				if ("," in author):	# "surname, forename"
+					words = author.split(',')
+					author = words[1].strip() + ' ' + words[0].strip() # "forename surname"
+				author = author.replace('. ',' ')	
+				author = author.replace('.',' ')				
+				author = author.replace('  ',' ')	
+				
+				# Check if the author exists, and import the author if not,  
+				# before starting any complicated book-name matching to save repeating the search
+				# 						
+			 	check_exist_author = myDB.action("SELECT * FROM authors where AuthorName=?",[author]).fetchone()
+			 	if not check_exist_author and lazylibrarian.ADD_AUTHOR:
+					# no match for supplied author, but we're allowed to add new ones
+
+					GR = GoodReads(author)
+					try:
+						author_gr = GR.find_author_id()
+					except:
+						logger.error("Error finding author id for [%s]" % author)
+						continue
+				
+					# only try to add if GR data matches found author data
+					# not sure what this is for, never seems to fail??
+					if author_gr:
+						authorname = author_gr['authorname']
+						
+						# "J.R.R. Tolkien" is the same person as "J. R. R. Tolkien" and "J R R Tolkien"
+						match_auth = author.replace('.','_')
+	                               	 	match_auth = match_auth.replace(' ','_')
+	                                	match_auth = match_auth.replace('__','_')
+						match_name = authorname.replace('.','_')
+	                               	 	match_name = match_name.replace(' ','_')
+	                                	match_name = match_name.replace('__','_')
+	
+						# allow a degree of fuzziness to cater for different accented character handling.
+						# some author names have accents, 
+						# filename may have the accented or un-accented version of the character
+						# The (currently non-configurable) value of fuzziness works for one accented character
+						# We stored GoodReads unmodified author name in author_gr, so store in LL db under that
+						match_fuzz = fuzz.ratio(match_auth, match_name)
+						if (match_fuzz < 90):						
+							logger.info("Failed to match author [%s] fuzz [%d]" % (author, match_fuzz))
+							logger.info("match author [%s] authorname [%s]" % (match_auth, match_name))
+							
+						# To save loading hundreds of books by unknown authors at GR or GB, ignore if author "Unknown"
+						if (author != "Unknown") and (match_fuzz >= 90):
+							# use "intact" name for author that we stored in 
+							# GR author_dict, not one of the various mangled versions
+							# otherwise the books appear to be by a different author!
+							author = author_gr['authorname']
+							# this new authorname may already be in the database, so check again
+							check_exist_author = myDB.action("SELECT * FROM authors where AuthorName=?",[author]).fetchone()
+			 				if not check_exist_author:
+								logger.info("Adding new author [%s]" % author)
+								if author not in new_authors:
+									new_authors.append(author)
 								try:
 									importer.addAuthorToDB(author)
+									check_exist_author = myDB.action("SELECT * FROM authors where AuthorName=?",[author]).fetchone()
 								except:
 									continue
-								check_exist_book = myDB.action("SELECT * FROM books where AuthorName=? and BookName=?",[author,book]).fetchone()
-								if check_exist_book:
-									if author not in new_authors:
-										new_authors.append(author)
-									myDB.action('UPDATE books set Status=? where AuthorName=? and BookName=?',['Open',author,book])
-									new_book_count += 1
-							else:
-								logger.info("Unable to match %s in GoodReads database" % author)
-							
+							 					
+				# check author exists in db, either newly loaded or already there
+			 	if not check_exist_author:
+					logger.info("Failed to match author [%s] in database" % author)
+				else:			
+					# author exists, check if this book by this author is in our database
+	                		bookid = find_book_in_db(myDB, author, book)
+	 				if bookid:
+						# check if book is already marked as "Open" (if so, we already had it)
+						check_status = myDB.action('SELECT Status from books where BookID=?',[bookid]).fetchone()
+						if check_status['Status'] != 'Open':
+							# update status as its a new found book
+							myDB.action('UPDATE books set Status=? where BookID=?',[u'Open',bookid])
+							new_book_count += 1
 
-				else:
-					if author not in new_authors:
-						new_authors.append(author)
-					myDB.action('UPDATE books set Status=? where AuthorName=? and BookName=?',['Open',author,book])
-					new_book_count += 1
 				
-				file_count += 1
-	
+	cachesize = myDB.action("select count(*) from languages").fetchone()
 	logger.info("%s new/modified books found and added to the database" % new_book_count)
+	logger.info("%s files processed" % file_count)
+	stats = myDB.action("SELECT sum(GR_book_hits), sum(GR_lang_hits), sum(LT_lang_hits), sum(GB_lang_change), sum(cache_hits), sum(bad_lang), sum(bad_char), sum(uncached) FROM stats").fetchone()
+	if lazylibrarian.BOOK_API == "GoogleBooks":
+		logger.info("GoogleBooks was hit %s times for books" % stats['sum(GR_book_hits)'])
+		logger.info("GoogleBooks language was changed %s times" % stats['sum(GB_lang_change)'])
+	if lazylibrarian.BOOK_API == "GoodReads":
+    		logger.info("GoodReads was hit %s times for books" % stats['sum(GR_book_hits)'])
+		logger.info("GoodReads was hit %s times for languages" % stats['sum(GR_lang_hits)'])
+	logger.info("LibraryThing was hit %s times for languages" % stats['sum(LT_lang_hits)'])
+	logger.info("Language cache was hit %s times" % stats['sum(cache_hits)'])
+	logger.info("Unwanted language removed %s books" % stats['sum(bad_lang)'])
+	logger.info("Unwanted characters removed %s books" % stats['sum(bad_char)'])
+	logger.info("Unable to cache %s books with missing ISBN" % stats['sum(uncached)'])
+	logger.info("ISBN Language cache holds %s entries" % cachesize['count(*)'])
+	stats = len(myDB.select('select BookID from Books where status=? and BookLang=?',['Open','Unknown']))
+	logger.info("There are %s books in your library with unknown language" % stats)
+		
 	logger.info('Updating %i authors' % len(new_authors))
 	for auth in new_authors:
 		havebooks = len(myDB.select('select BookName from Books where status=? and AuthorName=?',['Open',auth]))
 		myDB.action('UPDATE authors set HaveBooks=? where AuthorName=?',[havebooks,auth])
 		totalbooks = len(myDB.select('select BookName from Books where status!=? and AuthorName=?',['Ignored',auth]))
 		myDB.action('UPDATE authors set UnignoredBooks=? where AuthorName=?',[totalbooks,auth]) 
-
+		
 	logger.info('Library scan complete')

--- a/lazylibrarian/mobi.py
+++ b/lazylibrarian/mobi.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+Mobi.py
+
+Created by Elliot Kroo on 2009-12-25.
+Copyright (c) 2009 Elliot Kroo. All rights reserved.
+"""
+
+import sys
+import os
+import unittest
+from struct import *
+from mobilz77 import uncompress_lz77
+
+mobilangdict = {
+		54 : {0 : 'af'}, # Afrikaans
+		28 : {0 : 'sq'}, # Albanian
+		 1 : {0 : 'ar' , 5 : 'ar-dz' , 15 : 'ar-bh' , 3 : 'ar-eg' , 2 : 'ar-iq',  11 : 'ar-jo' , 13 : 'ar-kw' , 12 : 'ar-lb' , 4: 'ar-ly', 6 : 'ar-ma' , 8 : 'ar-om' , 16 : 'ar-qa' , 1 : 'ar-sa' , 10 : 'ar-sy' , 7 : 'ar-tn' , 14 : 'ar-ae' , 9 : 'ar-ye'}, # Arabic,  Arabic (Algeria),  Arabic (Bahrain),  Arabic (Egypt),  Arabic (Iraq), Arabic (Jordan),  Arabic (Kuwait),  Arabic (Lebanon),  Arabic (Libya), Arabic (Morocco),  Arabic (Oman),  Arabic (Qatar),  Arabic (Saudi Arabia),  Arabic (Syria),  Arabic (Tunisia),  Arabic (United Arab Emirates),  Arabic (Yemen)
+		43 : {0 : 'hy'}, # Armenian
+		77 : {0 : 'as'}, # Assamese
+		44 : {0 : 'az'}, # "Azeri (IANA: Azerbaijani)
+		45 : {0 : 'eu'}, # Basque
+		35 : {0 : 'be'}, # Belarusian
+		69 : {0 : 'bn'}, # Bengali
+		 2 : {0 : 'bg'}, # Bulgarian
+		 3 : {0 : 'ca'}, # Catalan
+		 4 : {0 : 'zh' , 3 : 'zh-hk' , 2 : 'zh-cn' , 4 : 'zh-sg' , 1 : 'zh-tw'}, # Chinese,  Chinese (Hong Kong),  Chinese (PRC),  Chinese (Singapore),  Chinese (Taiwan)
+		26 : {0 : 'hr'}, # Croatian
+		 5 : {0 : 'cs'}, # Czech
+		 6 : {0 : 'da'}, # Danish
+		19 : {1 : 'nl' , 2 : 'nl-be'}, # Dutch / Flemish,  Dutch (Belgium)
+		 9 : {1 : 'en' , 3 : 'en-au' , 40 : 'en-bz' , 4 : 'en-ca' , 6 : 'en-ie' , 8 : 'en-jm' , 5 : 'en-nz' , 13 : 'en-ph' , 7 : 'en-za' , 11 : 'en-tt' , 2 : 'en-gb', 1 : 'en-us' , 12 : 'en-zw'}, # English,  English (Australia),  English (Belize),  English (Canada),  English (Ireland),  English (Jamaica),  English (New Zealand),  English (Philippines),  English (South Africa),  English (Trinidad),  English (United Kingdom),  English (United States),  English (Zimbabwe)
+		37 : {0 : 'et'}, # Estonian
+		56 : {0 : 'fo'}, # Faroese
+		41 : {0 : 'fa'}, # Farsi / Persian
+		11 : {0 : 'fi'}, # Finnish
+		12 : {1 : 'fr' , 2 : 'fr-be' , 3 : 'fr-ca' , 5 : 'fr-lu' , 6 : 'fr-mc' , 4 : 'fr-ch'}, # French,  French (Belgium),  French (Canada),  French (Luxembourg),  French (Monaco),  French (Switzerland)
+		55 : {0 : 'ka'}, # Georgian
+		 7 : {1 : 'de' , 3 : 'de-at' , 5 : 'de-li' , 4 : 'de-lu' , 2 : 'de-ch'}, # German,  German (Austria),  German (Liechtenstein),  German (Luxembourg),  German (Switzerland)
+		 8 : {0 : 'el'}, # Greek, Modern (1453-)
+		71 : {0 : 'gu'}, # Gujarati
+		13 : {0 : 'he'}, # Hebrew (also code 'iw'?)
+		57 : {0 : 'hi'}, # Hindi
+		14 : {0 : 'hu'}, # Hungarian
+		15 : {0 : 'is'}, # Icelandic
+		33 : {0 : 'id'}, # Indonesian
+		16 : {1 : 'it' , 2 : 'it-ch'}, # Italian,  Italian (Switzerland)
+		17 : {0 : 'ja'}, # Japanese
+		75 : {0 : 'kn'}, # Kannada
+		63 : {0 : 'kk'}, # Kazakh
+		87 : {0 : 'x-kok'}, # Konkani (real language code is 'kok'?)
+		18 : {0 : 'ko'}, # Korean
+		38 : {0 : 'lv'}, # Latvian
+		39 : {0 : 'lt'}, # Lithuanian
+		47 : {0 : 'mk'}, # Macedonian
+		62 : {0 : 'ms'}, # Malay
+		76 : {0 : 'ml'}, # Malayalam
+		58 : {0 : 'mt'}, # Maltese
+		78 : {0 : 'mr'}, # Marathi
+		97 : {0 : 'ne'}, # Nepali
+		20 : {0 : 'no'}, # Norwegian
+		72 : {0 : 'or'}, # Oriya
+		21 : {0 : 'pl'}, # Polish
+		22 : {2 : 'pt' , 1 : 'pt-br'}, # Portuguese,  Portuguese (Brazil)
+		70 : {0 : 'pa'}, # Punjabi
+		23 : {0 : 'rm'}, # "Rhaeto-Romanic" (IANA: Romansh)
+		24 : {0 : 'ro'}, # Romanian
+		25 : {0 : 'ru'}, # Russian
+		59 : {0 : 'sz'}, # "Sami (Lappish)" (not an IANA language code)
+								  # IANA code for "Northern Sami" is 'se'
+								  # 'SZ' is the IANA region code for Swaziland
+		79 : {0 : 'sa'}, # Sanskrit
+		26 : {3 : 'sr'}, # Serbian
+		27 : {0 : 'sk'}, # Slovak
+		36 : {0 : 'sl'}, # Slovenian
+		46 : {0 : 'sb'}, # "Sorbian" (not an IANA language code)
+								  # 'SB' is IANA region code for 'Solomon Islands'
+								  # Lower Sorbian = 'dsb'
+								  # Upper Sorbian = 'hsb'
+								  # Sorbian Languages = 'wen'
+		10 : {0 : 'es' , 4 : 'es' , 44 : 'es-ar' , 64 : 'es-bo' , 52 : 'es-cl' , 36 : 'es-co' , 20 : 'es-cr' , 28 : 'es-do' , 48 : 'es-ec' , 68 : 'es-sv' , 16 : 'es-gt' , 72 : 'es-hn' , 8 : 'es-mx' , 76 : 'es-ni' , 24 : 'es-pa' , 60 : 'es-py' , 40 : 'es-pe' , 80 : 'es-pr' , 56 : 'es-uy' , 32 : 'es-ve'}, # Spanish,  Spanish (Mobipocket bug?),  Spanish (Argentina),  Spanish (Bolivia),  Spanish (Chile),  Spanish (Colombia),  Spanish (Costa Rica),  Spanish (Dominican Republic),  Spanish (Ecuador),  Spanish (El Salvador),  Spanish (Guatemala),  Spanish (Honduras),  Spanish (Mexico),  Spanish (Nicaragua),  Spanish (Panama),  Spanish (Paraguay),  Spanish (Peru),  Spanish (Puerto Rico),  Spanish (Uruguay),  Spanish (Venezuela)
+		48 : {0 : 'sx'}, # "Sutu" (not an IANA language code)
+								  # "Sutu" is another name for "Southern Sotho"?
+								  # IANA code for "Southern Sotho" is 'st'
+		65 : {0 : 'sw'}, # Swahili
+		29 : {0 : 'sv' , 1 : 'sv' , 8 : 'sv-fi'}, # Swedish,  Swedish (Finland)
+		73 : {0 : 'ta'}, # Tamil
+		68 : {0 : 'tt'}, # Tatar
+		74 : {0 : 'te'}, # Telugu
+		30 : {0 : 'th'}, # Thai
+		49 : {0 : 'ts'}, # Tsonga
+		50 : {0 : 'tn'}, # Tswana
+		31 : {0 : 'tr'}, # Turkish
+		34 : {0 : 'uk'}, # Ukrainian
+		32 : {0 : 'ur'}, # Urdu
+		67 : {2 : 'uz'}, # Uzbek
+		42 : {0 : 'vi'}, # Vietnamese
+		52 : {0 : 'xh'}, # Xhosa
+		53 : {0 : 'zu'}, # Zulu
+}
+  	
+
+class Mobi:
+
+  def toDict(tuples):
+    resultsDict = {}
+    for field, value in tuples:
+      if len(field) > 0 and field[0] != "-":
+        resultsDict[field] = value
+    return resultsDict;
+ 	
+  def parse(self):
+    """ reads in the file, then parses record tables"""
+    self.contents = self.f.read();
+    self.header = self.parseHeader();
+    self.records = self.parseRecordInfoList();
+    self.readRecord0()
+
+  def readRecord(self, recordnum, disable_compression=False):
+    if self.config:
+      if self.config['palmdoc']['Compression'] == 1 or disable_compression:
+        return self.contents[self.records[recordnum]['record Data Offset']:self.records[recordnum+1]['record Data Offset']];
+      elif self.config['palmdoc']['Compression'] == 2:
+        result = uncompress_lz77(self.contents[self.records[recordnum]['record Data Offset']:self.records[recordnum+1]['record Data Offset']-self.config['mobi']['extra bytes']])
+        return result
+
+  def readImageRecord(self, imgnum):
+    if self.config:
+      recordnum = self.config['mobi']['First Image index'] + imgnum;
+      return self.readRecord(recordnum, disable_compression=True);
+
+  def author(self):
+    "Returns the author of the book, or "" if none provided"
+    try:
+      txt = self.config['exth']['records'][100]
+      return txt
+    except:
+      return ""
+
+  def title(self):
+    "Returns the title of the book, or "" if none provided"
+    try:
+      txt = self.config['mobi']['Full Name']
+      return txt
+    except:
+      return ""
+
+  def language(self):
+    "Returns the language of the book, or "" if none provided"
+    try:
+      langcode = int(self.config['mobi']['Language'])
+      langID = langcode & 0xFF
+      sublangID = (langcode >> 10) & 0xFF
+      return mobilangdict.get(int(langID), {0 : 'en'}).get(int(sublangID), 'en')
+    except:
+      return ""
+
+  def isbn(self):
+    "Returns the isbn of the book, or "" if none provided"
+    try:
+      txt = self.config['exth']['records'][104]
+      return txt
+    except:
+      return ""
+
+###########  Private API ###########################
+
+  def __init__(self, filename):
+    try:
+      if isinstance(filename, str):
+        self.f = open(filename, "rb");
+      else:
+        self.f = filename;
+    except IOError,e:
+      sys.stderr.write("Could not open %s! " % filename);
+      raise e;
+    self.offset = 0;
+
+  def __iter__(self):
+    if not self.config: return;
+    for record in range(1, self.config['mobi']['First Non-book index'] - 1):
+      yield self.readRecord(record);
+
+  def parseRecordInfoList(self):
+    records = {};
+    # read in all records in info list
+    for recordID in range(self.header['number of records']):
+      headerfmt = '>II'
+      headerlen = calcsize(headerfmt)
+      fields = [
+        "record Data Offset",
+        "UniqueID",
+      ]
+      # create tuple with info
+      results = zip(fields, unpack(headerfmt, self.contents[self.offset:self.offset+headerlen]))
+
+      # increment offset into file
+      self.offset += headerlen
+
+      # convert tuple to dictionary
+      resultsDict = utils.toDict(results);
+
+      # futz around with the unique ID record, as the uniqueID's top 8 bytes are
+      # really the "record attributes":
+      resultsDict['record Attributes'] = (resultsDict['UniqueID'] & 0xFF000000) >> 24;
+      resultsDict['UniqueID'] = resultsDict['UniqueID'] & 0x00FFFFFF;
+
+      # store into the records dict
+      records[resultsDict['UniqueID']] = resultsDict;
+
+    return records;
+
+  def parseHeader(self):
+    headerfmt = '>32shhIIIIII4s4sIIH'
+    headerlen = calcsize(headerfmt)
+    fields = [
+      "name",
+      "attributes",
+      "version",
+      "created",
+      "modified",
+      "backup",
+      "modnum",
+      "appInfoId",
+      "sortInfoID",
+      "type",
+      "creator",
+      "uniqueIDseed",
+      "nextRecordListID",
+      "number of records"
+    ]
+
+    # unpack header, zip up into list of tuples
+    results = zip(fields, unpack(headerfmt, self.contents[self.offset:self.offset+headerlen]))
+
+    # increment offset into file
+    self.offset += headerlen
+
+    # convert tuple array to dictionary
+    resultsDict = utils.toDict(results);
+
+    return resultsDict
+
+  def readRecord0(self):
+    palmdocHeader = self.parsePalmDOCHeader();
+    MobiHeader = self.parseMobiHeader();
+    exthHeader = None
+    if MobiHeader['Has EXTH Header']:
+      exthHeader = self.parseEXTHHeader();
+
+    self.config = {
+      'palmdoc': palmdocHeader,
+      'mobi' : MobiHeader,
+      'exth' : exthHeader
+    }
+
+  def parseEXTHHeader(self):
+    headerfmt = '>III'
+    headerlen = calcsize(headerfmt)
+
+    fields = [
+      'identifier',
+      'header length',
+      'record Count'
+    ]
+
+    # unpack header, zip up into list of tuples
+    results = zip(fields, unpack(headerfmt, self.contents[self.offset:self.offset+headerlen]))
+
+    # convert tuple array to dictionary
+    resultsDict = utils.toDict(results);
+
+    self.offset += headerlen;
+    resultsDict['records'] = {};
+    for record in range(resultsDict['record Count']):
+      recordType, recordLen = unpack(">II", self.contents[self.offset:self.offset+8]);
+      recordData = self.contents[self.offset+8:self.offset+recordLen];
+      resultsDict['records'][recordType] = recordData;
+      self.offset += recordLen;
+
+    return resultsDict;
+
+  def parseMobiHeader(self):
+    headerfmt = '> IIII II 40s III IIIII IIII I 36s IIII 8s HHIIIII'
+    headerlen = calcsize(headerfmt)
+
+    fields = [
+      "identifier",
+      "header length",
+      "Mobi type",
+      "text Encoding",
+
+      "Unique-ID",
+      "Generator version",
+
+      "-Reserved",
+
+      "First Non-book index",
+      "Full Name Offset",
+      "Full Name Length",
+
+      "Language",
+      "Input Language",
+      "Output Language",
+      "Format version",
+      "First Image index",
+
+      "First Huff Record",
+      "Huff Record Count",
+      "First DATP Record",
+      "DATP Record Count",
+
+      "EXTH flags",
+
+      "-36 unknown bytes, if Mobi is long enough",
+
+      "DRM Offset",
+      "DRM Count",
+      "DRM Size",
+      "DRM Flags",
+
+      "-Usually Zeros, unknown 8 bytes",
+
+      "-Unknown",
+      "Last Image Record",
+      "-Unknown",
+      "FCIS record",
+      "-Unknown",
+      "FLIS record",
+      "Unknown"
+    ]
+
+    # unpack header, zip up into list of tuples
+    results = zip(fields, unpack(headerfmt, self.contents[self.offset:self.offset+headerlen]))
+
+    # convert tuple array to dictionary
+    resultsDict = utils.toDict(results);
+
+    resultsDict['Start Offset'] = self.offset;
+
+    resultsDict['Full Name'] = (self.contents[
+      self.records[0]['record Data Offset'] + resultsDict['Full Name Offset'] :
+      self.records[0]['record Data Offset'] + resultsDict['Full Name Offset'] + resultsDict['Full Name Length']])
+
+    resultsDict['Has DRM'] = resultsDict['DRM Offset'] != 0xFFFFFFFF;
+
+    resultsDict['Has EXTH Header'] = (resultsDict['EXTH flags'] & 0x40) != 0;
+
+    self.offset += resultsDict['header length'];
+
+    def onebits(x, width=16):
+        return len(filter(lambda x: x == "1", (str((x>>i)&1) for i in xrange(width-1,-1,-1))));
+
+    resultsDict['extra bytes'] = 2*onebits(unpack(">H", self.contents[self.offset-2:self.offset])[0] & 0xFFFE)
+
+    return resultsDict;
+
+  def parsePalmDOCHeader(self):
+    headerfmt = '>HHIHHHH'
+    headerlen = calcsize(headerfmt)
+    fields = [
+      "Compression",
+      "Unused",
+      "text length",
+      "record count",
+      "record size",
+      "Encryption Type",
+      "Unknown"
+    ]
+    offset = self.records[0]['record Data Offset'];
+    # create tuple with info
+    results = zip(fields, unpack(headerfmt, self.contents[offset:offset+headerlen]))
+
+    # convert tuple array to dictionary
+    resultsDict = utils.toDict(results);
+
+    self.offset = offset+headerlen;
+    return resultsDict
+
+class MobiTests(unittest.TestCase):
+  def setUp(self):
+    self.mobitest = Mobi("../test/CharlesDarwin.mobi");
+  def testParse(self):
+    self.mobitest.parse();
+    print (self.mobitest.config)
+  def testRead(self):
+    self.mobitest.parse();
+    content = ""
+    for i in range(1,5):
+      content += self.mobitest.readRecord(i);
+  def testImage(self):
+    self.mobitest.parse();
+    print (self.mobitest.records);
+    for record in range(4):
+      f = open("imagerecord%d.jpg" % record, 'w')
+      f.write(self.mobitest.readImageRecord(record));
+      f.close();
+  def testAuthorTitle(self):
+    self.mobitest.parse()
+    self.assertEqual(self.mobitest.author(), 'Charles Darwin')
+    self.assertEqual(self.mobitest.title(), 'The Origin of Species by means '+
+        'of Natural Selection, 6th Edition')
+
+if __name__ == '__main__':
+  unittest.main()

--- a/lazylibrarian/mobilz77.py
+++ b/lazylibrarian/mobilz77.py
@@ -1,0 +1,86 @@
+import struct
+# ported directly from the PalmDoc Perl library
+# http://kobesearch.cpan.org/htdocs/EBook-Tools/EBook/Tools/PalmDoc.pm.html
+
+def uncompress_lz77(data):
+  length = len(data);
+  offset = 0;   # Current offset into data
+  # char;      # Character being examined
+  # ord;      # Ordinal of $char
+  # lz77;      # 16-bit Lempel-Ziv 77 length-offset pair
+  # lz77offset;   # LZ77 offset
+  # lz77length;   # LZ77 length
+  # lz77pos;    # Position inside $lz77length
+  text = '';   # Output (uncompressed) text
+  # textlength;   # Length of uncompressed text during LZ77 pass
+  # textpos;    # Position inside $text during LZ77 pass
+
+  while offset < length:
+    # char = substr($data,$offset++,1);
+    char = data[offset];
+    offset += 1;
+    ord_ = ord(char);
+
+    # print " ".join([repr(char), hex(ord_)])
+
+    # The long if-elsif chain is the best logic for $ord handling
+    ## no critic (Cascading if-elsif chain)
+    if (ord_ == 0):
+      # Nulls are literal
+      text += char;
+    elif (ord_ <= 8):
+      # Next $ord bytes are literal
+      text += data[offset:offset+ord_] # text .=substr($data,$offset,ord);
+      offset += ord_;
+    elif (ord_ <= 0x7f):
+      # Values from 0x09 through 0x7f are literal
+      text += char;
+    elif (ord_ <= 0xbf):
+      # Data is LZ77-compressed
+
+      # From Wikipedia:
+      # "A length-distance pair is always encoded by a two-byte
+      # sequence. Of the 16 bits that make up these two bytes,
+      # 11 bits go to encoding the distance, 3 go to encoding
+      # the length, and the remaining two are used to make sure
+      # the decoder can identify the first byte as the beginning
+      # of such a two-byte sequence."
+
+      offset += 1;
+      if (offset > len(data)):
+        print("WARNING: offset to LZ77 bits is outside of the data: %d" % offset);
+        return text;
+
+      lz77, = struct.unpack('>H', data[offset-2:offset])
+
+      # Leftmost two bits are ID bits and need to be dropped
+      lz77 &= 0x3fff;
+
+      # Length is rightmost 3 bits + 3
+      lz77length = (lz77 & 0x0007) + 3;
+
+      # Remaining 11 bits are offset
+      lz77offset = lz77 >> 3;
+      if (lz77offset < 1):
+        print("WARNING: LZ77 decompression offset is invalid!");
+        return text;
+
+      # Getting text from the offset is a little tricky, because
+      # in theory you can be referring to characters you haven't
+      # actually decompressed yet. You therefore have to check
+      # the reference one character at a time.
+      textlength = len(text);
+      for lz77pos in range(lz77length): # for($lz77pos = 0; $lz77pos < $lz77length; $lz77pos++)
+        textpos = textlength - lz77offset;
+        if (textpos < 0):
+          print("WARNING: LZ77 decompression reference is before"+
+                " beginning of text! %x" % lz77);
+          return;
+
+        text += text[textpos:textpos+1]; #text .= substr($text,$textpos,1);
+        textlength+=1;
+    else:
+      # 0xc0 - 0xff are single characters (XOR 0x80) preceded by
+      # a space
+      text += ' ' + chr(ord_ ^ 0x80);
+  return text;

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -78,7 +78,8 @@ class WebInterface(object):
 		    "proxy_host":	lazylibrarian.PROXY_HOST,
 		    "proxy_type":	lazylibrarian.PROXY_TYPE,
                     "logdir" :          lazylibrarian.LOGDIR,
-                    "use_imp_onlyisbn": checked(lazylibrarian.IMP_ONLYISBN),
+                    "imp_onlyisbn": 	checked(lazylibrarian.IMP_ONLYISBN),
+                    "imp_singlebook": 	checked(lazylibrarian.IMP_SINGLEBOOK),
                     "imp_preflang":     lazylibrarian.IMP_PREFLANG,
                     "imp_autoadd":      lazylibrarian.IMP_AUTOADD,
                     "sab_host":         lazylibrarian.SAB_HOST,
@@ -174,7 +175,7 @@ class WebInterface(object):
         return serve_template(templatename="config.html", title="Settings", config=config)    
     config.exposed = True
 
-    def configUpdate(self, http_host='0.0.0.0', http_root=None, http_user=None, http_port=5299, http_pass=None, http_look=None, launch_browser=0, logdir=None, imp_onlyisbn=0, imp_preflang=None, imp_autoadd=None, match_ratio=80, nzb_downloader_sabnzbd=0, nzb_downloader_nzbget=0, nzb_downloader_blackhole=0, use_nzb=0, use_tor=0, proxy_host=None, proxy_type=None,
+    def configUpdate(self, http_host='0.0.0.0', http_root=None, http_user=None, http_port=5299, http_pass=None, http_look=None, launch_browser=0, logdir=None, imp_onlyisbn=0, imp_singlebook=1, imp_preflang=None, imp_autoadd=None, match_ratio=80, nzb_downloader_sabnzbd=0, nzb_downloader_nzbget=0, nzb_downloader_blackhole=0, use_nzb=0, use_tor=0, proxy_host=None, proxy_type=None,
         sab_host=None, sab_port=None, sab_subdir=None, sab_api=None, sab_user=None, sab_pass=None, destination_copy=0, destination_dir=None, download_dir=None, sab_cat=None, usenet_retention=None, nzb_blackholedir=None, torrent_dir=None, numberofseeders=0, tor_downloader_blackhole=0, tor_downloader_utorrent=0,
         nzbget_host=None, nzbget_user=None, nzbget_pass=None, nzbget_cat=None, nzbget_priority=0,
         newznab=0, newznab_host=None, newznab_api=None, newznab2=0, newznab_host2=None, newznab_api2=None,newzbin=0, newzbin_uid=None, newzbin_pass=None, kat=0, ebook_type=None, book_api=None, gr_api=None, gb_api=None, usenetcrawler = 0, usenetcrawler_host=None, usenetcrawler_api = None, 
@@ -198,6 +199,7 @@ class WebInterface(object):
         lazylibrarian.MATCH_RATIO = match_ratio
 
         lazylibrarian.IMP_ONLYISBN = imp_onlyisbn
+        lazylibrarian.IMP_SINGLEBOOK = imp_singlebook
         lazylibrarian.IMP_PREFLANG = imp_preflang
         lazylibrarian.IMP_AUTOADD  = imp_autoadd
 


### PR DESCRIPTION
Added LibraryThing for language lookups.
Use local metadata where available, either opf files or look inside ebooks
Cache language lookups to save so many calls to APIs and also to save time. 
Added LibraryThing language to googlebooks too, as google often incorrectly reports books as "en" when they are not.
Optimised for multiple formats of same book in the same directory
Added stats table to database to report on cache use and api hits 
Uses additional modules: unidecode, lxml, zipfile