### PR TITLE
Fix for accented characters in magazine names. NOTE only works with m…

### DIFF
--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -721,6 +721,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS wanted (BookID TEXT, NZBurl TEXT, NZBtitle TEXT, NZBdate TEXT, NZBprov TEXT, Status TEXT, NZBsize TEXT, AuxInfo TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS magazines (Title TEXT, Frequency TEXT, Regex TEXT, Status TEXT, MagazineAdded TEXT, LastAcquired TEXT, IssueDate TEXT, IssueStatus TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS languages ( isbn TEXT, lang TEXT )')
+    c.execute('CREATE TABLE IF NOT EXISTS stats ( authorname text, GR_book_hits int, GR_lang_hits int, LT_lang_hits int, GB_lang_change, cache_hits int, bad_lang int, bad_char int, uncached int )')
 
     try:
         logger.info('Checking database')

--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -471,7 +471,7 @@ class GoogleBooks:
 			    logger.info("[%s] removed book for bad characters" % (bookname))
 			    removedResults = removedResults + 1
 
-        except Keyerror:
+        except KeyError:
             pass
 
         logger.info('[%s] The Google Books API was hit %s times to populate book list' % (authorname, str(api_hits)))

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -38,8 +38,9 @@ def get_book_info(fname):
     #	  txt = pdf.getDocumentInfo()
 	  # repackage the data here to get components we need
     #     res = {}
-    #     for s in ['title','language','creator','isbn']:
+    #     for s in ['title','language','creator']:
     #         res[s] = txt[s]
+    #	  res['identifier'] = txt['isbn']
     #	  return res
 
     if (extn == "epub"):
@@ -89,8 +90,7 @@ def get_book_info(fname):
 			isbn = txt
 		elif len(txt) == 10:
 			if txt[:8].isdigit():
-				isbn = txt
-		
+				isbn = txt	
     		res['identifier'] = isbn
 	n = n + 1
     return res
@@ -269,14 +269,12 @@ def LibraryScan(dir=None):
 				try:
 					metafile = os.path.join(r,"metadata.opf").encode(lazylibrarian.SYS_ENCODING)
 					res = get_book_info(metafile)
-					if res:
-						book = res['title']
-						author = res['creator']
-						language = res['language']
-						isbn = res['identifier']
-						match = 1
-						logger.debug("file meta [%s] [%s] [%s] [%s]" % (isbn,language,author,book))
-
+					book = res['title']
+					author = res['creator']
+					language = res['language']
+					isbn = res['identifier']
+					match = 1
+					logger.debug("file meta [%s] [%s] [%s] [%s]" % (isbn,language,author,book))
 				except:
 					logger.debug("No metadata file in %s" % r)
 

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -98,7 +98,10 @@ def searchmagazines(mags=None):
 					if len(nzbtitle_exploded) > name_len: # needs to be longer as it should include a date
 					    while name_len:
 						name_len = name_len - 1
-						if nzbtitle_exploded[name_len].lower() != bookid_exploded[name_len].lower():
+						# fuzzy check on each word in the magazine name
+						ratio = fuzz.ratio(nzbtitle_exploded[name_len].lower(), bookid_exploded[name_len].lower())
+						if ratio < 80: # hard coded fuzz ratio for now, works for close matches
+							logger.debug("Magazine fuzz ratio failed [%d] [%s] [%s]" % (ratio, bookid, nzbtitle_formatted))
 							name_match = 0 # name match failed
 					if name_match:	
 						if len(nzbtitle_exploded) > 1:

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -18,7 +18,7 @@ from lazylibrarian.gr import GoodReads
 from lazylibrarian.gb import GoogleBooks
 
 import lib.simplejson as simplejson
-
+from lib.unidecode import unidecode
 
 def serve_template(templatename, **kwargs):
 
@@ -522,7 +522,7 @@ class WebInterface(object):
             if os.path.isdir(dest_dir):
                 for file2 in os.listdir(dest_dir):    
                     if ((file2.lower().find(".jpg") <= 0) & (file2.lower().find(".opf") <= 0)):
-                        logger.info('Opening file ' + str(file2))
+                        logger.info('Opening file ' + file2)
                         return serve_file(os.path.join(dest_dir, file2), "application/x-download", "attachment")
     openBook.exposed = True
 
@@ -546,7 +546,7 @@ class WebInterface(object):
             if os.path.isdir(dest_dir):
                 for file2 in os.listdir(dest_dir):  
                     if ((file2.lower().find(".jpg") <= 0) & (file2.lower().find(".opf") <= 0)):
-                        logger.info('Opening file ' + str(file2))
+                        logger.info('Opening file ' + file2)
                         return serve_file(os.path.join(dest_dir, file2), "application/x-download", "attachment")
     openMag.exposed = True
 
@@ -568,7 +568,7 @@ class WebInterface(object):
             if (lazylibrarian.USE_TOR):
                 threading.Thread(target=search_tor_book, args=[books, mags]).start()
 
-            logger.debug("Searching for book with id: " + str(bookid));
+            logger.debug("Searching for book with id: " + bookid);
         if AuthorName:
             raise cherrypy.HTTPRedirect("authorPage?AuthorName=%s" % AuthorName)
     searchForBook.exposed = True
@@ -791,7 +791,7 @@ class WebInterface(object):
                     threading.Thread(target=search_nzb_book, args=[books, mags]).start()
                 if (lazylibrarian.USE_TOR):
                     threading.Thread(target=search_tor_book, args=[books, mags]).start()
-                logger.debug("Searching for magazine with title: " + str(title));
+                logger.debug("Searching for magazine with title: " + title);
                 raise cherrypy.HTTPRedirect("magazines")
     addKeyword.exposed = True
 
@@ -808,7 +808,7 @@ class WebInterface(object):
                     myDB.upsert("magazines", newValueDict, controlValueDict)
                     logger.info('Status of magazine %s changed to %s' % (item, action))
                 elif (action == "Delete"):
-                    myDB.action('DELETE from magazines WHERE Title=?', [item])
+		    myDB.action('DELETE from magazines WHERE Title=\"%s\"' % item)
                     logger.info('Magazine %s removed from database' % item)
                 elif (action == "Reset"):
                     controlValueDict = {"Title": item}
@@ -838,7 +838,7 @@ class WebInterface(object):
                 threading.Thread(target=search_nzb_book, args=[books, mags]).start()
             if (lazylibrarian.USE_TOR):
                 threading.Thread(target=search_tor_book, args=[books, mags]).start()
-            logger.debug("Searching for magazine with title: " + str(bookid));
+            logger.debug("Searching for magazine with title: " + bookid);
             raise cherrypy.HTTPRedirect("magazines")
     searchForMag.exposed = True
 
@@ -855,7 +855,7 @@ class WebInterface(object):
                     myDB.upsert("wanted", newValueDict, controlValueDict)
                     logger.info('Status of wanted item %s changed to %s' % (nzbtitle, action))
                 else:
-                    myDB.action('DELETE from wanted WHERE NZBtitle=?', [nzbtitle])
+                    myDB.action('DELETE from wanted WHERE NZBtitle=\"%s\"' % nzb['nzbtitle'])
                     logger.info('Item %s removed from wanted' % nzbtitle)
                 raise cherrypy.HTTPRedirect("wanted")
     markWanted.exposed = True


### PR DESCRIPTION
…agazines where the month names are in English at the moment. Accented characters should be fixed now.

Need to rewrite the month2num code in formatter.py to be language independant??
ie a french magazine might have nzb title "Competences Mac N 31   Septembre Octobre 2013"
but we look for "September" in english, so fail to match. If we use the local language, assuming the downloader is french, we will match Septembre, but then the french user can't download english magazines. Any suggestions??