### PR TITLE
Fix ExecStart Line

### DIFF
--- a/init/lazylibrarian.service
+++ b/init/lazylibrarian.service
@@ -56,7 +56,7 @@
 Description=LazyLibrarian
 
 [Service]
-ExecStart=/home/lazylibrarian/LazyLibrarian.py --daemon --config /home/lazylibrarian/lazylibrarian.ini --datadir /home/lazylibrarian/.lazylibrarian --nolaunch --quiet
+ExecStart=/usr/bin/python /home/lazylibrarian/LazyLibrarian.py --daemon --config /home/lazylibrarian/lazylibrarian.ini --datadir /home/lazylibrarian/.lazylibrarian --nolaunch --quiet
 GuessMainPID=no
 Type=forking
 User=lazylibrarian


### PR DESCRIPTION
Because there is no #!/usr/bin/python in the top of the LazyLibrarian.py file, the ExecStart line of the systemd service file must explicitly call Python.