### PR TITLE
Lots of additions, fixes for 132, 188, 190

### DIFF
--- a/LazyLibrarian.py
+++ b/LazyLibrarian.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os, sys, time, cherrypy, threading, locale
 from lib.configobj import ConfigObj
 

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -646,9 +646,9 @@
                         <div class="row">
                             <input type="checkbox" name="pushover_onsnatch" value="1" ${config['pushover_onsnatch']} />Notify on snatch
                         </div>
-			<div class="row">
-			    <input type="checkbox" name="pushover_ondownload" value="1" ${config['pushover_ondownload']} />Notify on download
-			</div>
+			            <div class="row">
+			                <input type="checkbox" name="pushover_ondownload" value="1" ${config['pushover_ondownload']} />Notify on download
+			            </div>
                         <div class="row">
                             <input type="text" name="pushover_apitoken" value="${config['pushover_apitoken']}" size="35" placeholder="Pushover API Token">
                         </div>
@@ -656,7 +656,13 @@
                             <input type="text" name="pushover_keys" value="${config['pushover_keys']}" size="35" placeholder="Pushover Keys">
                         </div>
                         <div class="row">
+                            <input type="text" name="pushover_device" value="${config['pushover_device']}" size="35" placeholder="Pushover Device">
+                        </div>                        
+                        <div class="row">
                             <input type="text" name="pushover_priority" value="${config['pushover_priority']}" size="35" placeholder="Pushover Priority">
+                        </div>
+                        <div class="row">
+                            <input type="button" value="Test Pushover" id="testPushover">
                         </div>
                     </div>
                 </fieldset>
@@ -1108,6 +1114,12 @@
 
             $('#testPushbullet').click(function () {
                 $.get("testPushbullet",
+                    function (data) { window.alert(data) });
+                    
+            });
+
+            $('#testPushover').click(function () {
+                $.get("testPushover",
                     function (data) { window.alert(data) });
                     
             });

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -464,6 +464,7 @@
                     </div>
                 </td>
                 <td>
+                <label>Alternate Import Folder:</label><input type="text" name="alternate_dir" value="${config['alternate_dir']}" size="50">
                 </td>
             </tr>
             <tr>

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -7,7 +7,8 @@
     <div id="subhead_container">
         <ul id="subhead_menu">
             <li><a href="forceUpdate" id="button"> Refresh Active Authors </a></li>
-	     <li><a href="libraryScan?" id="button"> Library Scan </a></li>
+	     <li><a href="libraryScan" id="button"> Library Scan </a></li>
+	     <li><a href="importAlternate" id="button"> Import from Alternate folder </a></li>
         </ul>
     </div>
 </%def>

--- a/data/interfaces/default/issues.html
+++ b/data/interfaces/default/issues.html
@@ -1,0 +1,77 @@
+<%inherit file="base.html" />
+<%!
+    from lazylibrarian import database
+%>
+
+<%def name="headerIncludes()">
+    <div id="subhead_container">
+    <form action="addKeyword" method="get"><input type="hidden" name="type" value="issues">
+        <ul id="subhead_menu">
+            <li><a href="forceSearch?source=magazines" id="button"> Force Search </a></li>
+            <li><a href="forceProcess?source=magazines" id="button"> Force Post-Processing </a></li>
+            <li><a href="magazineScan" id="button"> Library Scan </a></li>
+            <li><a href="history?source=magazines" id="button"> Past Issues </a></li>
+        </ul>
+    </form>
+    </div>
+</%def>
+
+<%def name="body()">
+
+    <table class="display" id="book_table" style="margin-top:60px;">
+        <thead>
+            <tr>
+                <th id="magtitle">Issues of Magazine</th>
+                <th id="issuedate">Issue Date</th>
+                <th id="issueacquired">Issue&nbsp;Acquired</th>
+                <th id="issue">Open Issue</th>
+            </tr>
+        </thead>
+
+        <tbody>
+        %for result in issues:
+                <tr class="gradeZ">
+                    <td id="magtitle">${result['Title']}</td>
+                    <td id="issuedate">${result['IssueDate']}</td>
+                    <td id="issueacquired">${result['IssueAcquired']}</td>
+                    <td id="issue"><a class="button green" href="openMag?bookid=${result['IssueFile']}" target="_self">${"Open"}</a></td>
+                </tr>
+        %endfor
+        </tbody>
+    </table>
+</%def>
+
+<%def name="headIncludes()">
+    <link rel="stylesheet" href="css/data_table.css">
+</%def>
+
+<%def name="javascriptIncludes()">
+    <script src="js/libs/jquery.dataTables.min.js"></script>
+    <script>
+        
+    $(document).ready(function()
+    {
+
+        $('#book_table').dataTable(
+            {
+                "aoColumns": [
+                    null,
+                    null,
+                    null,
+                    null
+                    ],
+                "oLanguage": {
+                    "sLengthMenu":"Show _MENU_ issues per page",
+                    "sEmptyTable": "No issues found",
+                    "sInfo":"Showing _START_ to _END_ of _TOTAL_ results",
+                    "sInfoEmpty":"Showing 0 to 0 of 0 issues",
+                    "sInfoFiltered":"(filtered from _MAX_ total issues)"},
+                "sPaginationType": "full_numbers",
+                "bStateSave": true,
+                "aLengthMenu": [[5, 10, 15, 25, 50, 100, -1], [5, 10, 15, 25, 50, 100, "All"]],
+                "iDisplayLength": 10,
+            });
+            $('.dataTables_filter input').attr("placeholder", "Seach table here");
+    });
+    </script>
+</%def>

--- a/data/interfaces/default/magazines.html
+++ b/data/interfaces/default/magazines.html
@@ -10,7 +10,7 @@
             <li><a href="forceSearch?source=magazines" id="button"> Force Search </a></li>
             <li><a href="forceProcess?source=magazines" id="button"> Force Post-Processing </a></li>
             <li><a href="magazineScan" id="button"> Library Scan </a></li>
-            <li><a href="history?source=magazines" id="button"> Past Issues </a></li>
+            <li><a href="history?source=magazines" id="button"> Skipped Issues </a></li>
                 <div style="float:right; margin-right:15px; margin-top:2px;">
                 <li><input type="text" placeholder="Magazine Title" name="title"></li>
                 <li><select name="frequency">

--- a/data/interfaces/default/magazines.html
+++ b/data/interfaces/default/magazines.html
@@ -9,6 +9,7 @@
         <ul id="subhead_menu">
             <li><a href="forceSearch?source=magazines" id="button"> Force Search </a></li>
             <li><a href="forceProcess?source=magazines" id="button"> Force Post-Processing </a></li>
+            <li><a href="magazineScan" id="button"> Library Scan </a></li>
             <li><a href="history?source=magazines" id="button"> Past Issues </a></li>
                 <div style="float:right; margin-right:15px; margin-top:2px;">
                 <li><input type="text" placeholder="Magazine Title" name="title"></li>

--- a/data/interfaces/default/managebooks.html
+++ b/data/interfaces/default/managebooks.html
@@ -13,7 +13,7 @@
     <br><br>
     <form action="manage" method="get">
     Manage books with status <select name="whichStatus">
-        %for item in ['Skipped', 'Wanted', 'Snatched', 'Have', 'Ignored']:
+        %for item in ['Skipped', 'Wanted', 'Open', 'Have', 'Ignored']:
             <option value="${item}"
                 %if whichStatus == item:
                     selected = "selected"

--- a/data/interfaces/default/managemags.html
+++ b/data/interfaces/default/managemags.html
@@ -11,22 +11,7 @@
 
 <%def name="body()">
     <br><br>
-<!-- 
-    <form action="manage" method="get">
-    Manage magazines with status <select name="whichStatus">
-        %for item in ['Skipped', 'Wanted', 'Snatched', 'Have', 'Ignored']:
-            <option value="${item}"
-                %if whichStatus == item:
-                    selected = "selected"
-                %endif
-            >${item}</option>
-        %endfor
-    </select>
-    <input  class="btn" type="submit" value="Manage" />
-    </form>
-    <br>
--->
-    %if len(books) > 0:
+
     <h3>Magazines with status ${whichStatus}</h3>
         <br>
     <form action="markMags" method="get"><input type="hidden" name="redirect" value="manage">
@@ -67,7 +52,6 @@
         <input type="submit" class="markMags" value="Go">
     </p>
     </form>
-    %endif
 
 </%def>
 
@@ -92,16 +76,16 @@
                     ],
                 "oLanguage": {
                     "sLengthMenu":"Show _MENU_ magazines per page",
-                    "sEmptyTable": "No magazines found",
+                    "sEmptyTable": "No skipped issues found",
                     "sInfo":"Showing _START_ to _END_ of _TOTAL_ results",
                     "sInfoEmpty":"Showing 0 to 0 of 0 magazines",
                     "sInfoFiltered":"(filtered from _MAX_ total magazines)"},
+                "sPaginationType": "full_numbers",
                 "bStateSave": true,
                 "aLengthMenu": [[5, 10, 15, 25, 50, 100, -1], [5, 10, 15, 25, 50, 100, "All"]],
                 "iDisplayLength": 10,
-                "sPaginationType": "full_numbers",
             });
-			$('.dataTables_filter input').attr("placeholder", "Search table here");
+            $('.dataTables_filter input').attr("placeholder", "Seach table here");
     });
     </script>
 </%def>

--- a/data/interfaces/default/managemags.html
+++ b/data/interfaces/default/managemags.html
@@ -58,7 +58,7 @@
     <p>
 
     Change selected magazines to <select class="markMags" name="action" style="margin-left:30px;margin-top:15px;margin-bottom:15px;">
-        %for item in ['Skipped', 'Wanted', 'Snatched', 'Have', 'Ignored']:
+        %for item in ['Skipped', 'Wanted', 'Have', 'Ignored']:
             %if whichStatus != item:
                 <option value="${item}">${item}</option>
             %endif

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -18,8 +18,7 @@ from lib.apscheduler.scheduler import Scheduler
 
 import threading
 
-from lazylibrarian import logger, postprocess, searchnzb, searchtorrents, SimpleCache, librarysync, versioncheck, database, searchmag, magazinescan
-from common import remove_accents
+from lazylibrarian import logger, postprocess, searchnzb, searchtorrents, SimpleCache, librarysync, versioncheck, database, searchmag, magazinescan, common
 
 FULL_PATH = None
 PROG_DIR = None
@@ -85,6 +84,7 @@ NZBGET_PRIORITY = None
 
 DESTINATION_COPY = 0
 DESTINATION_DIR = None
+ALTERNATE_DIR = None
 DOWNLOAD_DIR = None
 
 IMP_PREFLANG = None
@@ -344,7 +344,7 @@ def initialize():
             HTTP_LOOK, LAUNCH_BROWSER, LOGDIR, CACHEDIR, MATCH_RATIO, PROXY_HOST, PROXY_TYPE, IMP_ONLYISBN, IMP_SINGLEBOOK, IMP_PREFLANG, IMP_MONTHLANG, IMP_AUTOADD, \
             MONTHNAMES, MONTH0, MONTH1, MONTH2, MONTH3, MONTH4, MONTH5, MONTH6, MONTH7, MONTH8, MONTH9, MONTH10, MONTH11, MONTH12, \
             SAB_HOST, SAB_PORT, SAB_SUBDIR, SAB_API, SAB_USER, SAB_PASS, DESTINATION_DIR, DESTINATION_COPY, DOWNLOAD_DIR, SAB_CAT, USENET_RETENTION, NZB_BLACKHOLEDIR, \
-            GR_API, GB_API, BOOK_API, NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, NZB_DOWNLOADER_NZBGET, \
+            ALTERNATE_DIR, GR_API, GB_API, BOOK_API, NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, NZB_DOWNLOADER_NZBGET, \
             NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, NEWZNAB0, NEWZNAB_HOST0, NEWZNAB_API0, \
             NEWZNAB1, NEWZNAB_HOST1, NEWZNAB_API1, NEWZNAB2, NEWZNAB_HOST2, NEWZNAB_API2, NEWZNAB3, NEWZNAB_HOST3, NEWZNAB_API3, NEWZNAB4, NEWZNAB_HOST4, NEWZNAB_API4, \
             TORZNAB0, TORZNAB_HOST0, TORZNAB_API0, TORZNAB1, TORZNAB_HOST1, TORZNAB_API1, TORZNAB2, TORZNAB_HOST2, TORZNAB_API2, \
@@ -443,6 +443,7 @@ def initialize():
 
         DESTINATION_COPY = check_setting_int(CFG, 'General', 'destination_copy', 0)
         DESTINATION_DIR = check_setting_str(CFG, 'General', 'destination_dir', '')
+        ALTERNATE_DIR = check_setting_str(CFG, 'General', 'alternate_dir', '')
         DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'download_dir', '')
 
         USE_NZB = check_setting_int(CFG, 'DLMethod', 'use_nzb', 0)
@@ -624,10 +625,10 @@ def build_monthtable():
     lang = str(current_locale)
     MONTHNAMES[0].append(lang)
     for f in range(1, 13):
-        MONTHNAMES[f].append(remove_accents(calendar.month_name[f]).lower())
+        MONTHNAMES[f].append(common.remove_accents(calendar.month_name[f]).lower())
     MONTHNAMES[0].append(lang)
     for f in range(1, 13):
-        MONTHNAMES[f].append(remove_accents(calendar.month_abbr[f]).lower().strip('.'))
+        MONTHNAMES[f].append(common.remove_accents(calendar.month_abbr[f]).lower().strip('.'))
     logger.info("Added month names for locale [%s], %s, %s ..." % (
         lang, MONTHNAMES[1][len(MONTHNAMES[1]) - 2], MONTHNAMES[1][len(MONTHNAMES[1]) - 1]))
 
@@ -638,10 +639,10 @@ def build_monthtable():
                 locale.setlocale(locale.LC_ALL, lang)
                 MONTHNAMES[0].append(lang)
                 for f in range(1, 13):
-                    MONTHNAMES[f].append(remove_accents(calendar.month_name[f]).lower())
+                    MONTHNAMES[f].append(common.remove_accents(calendar.month_name[f]).lower())
                 MONTHNAMES[0].append(lang)
                 for f in range(1, 13):
-                    MONTHNAMES[f].append(remove_accents(calendar.month_abbr[f]).lower().strip('.'))
+                    MONTHNAMES[f].append(common.remove_accents(calendar.month_abbr[f]).lower().strip('.'))
                 logger.info("Added month names for locale [%s], %s, %s ..." % (
                     lang, MONTHNAMES[1][len(MONTHNAMES[1]) - 2], MONTHNAMES[1][len(MONTHNAMES[1]) - 1]))
         except:
@@ -765,6 +766,7 @@ def config_write():
     new_config['NZBGet']['nzbget_priority'] = NZBGET_PRIORITY
 
     new_config['General']['destination_dir'] = DESTINATION_DIR
+    new_config['General']['alternate_dir'] = ALTERNATE_DIR
     new_config['General']['destination_copy'] = int(DESTINATION_COPY)
     new_config['General']['download_dir'] = DOWNLOAD_DIR
 

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -92,6 +92,14 @@ def is_valid_isbn(isbn):
                     return 1
     return 0
 
+def is_valid_booktype(filename):
+    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
+    if '.' in filename:
+        words = filename.split('.')
+        extn = words[len(words) - 1]
+        if extn in booktype_list:
+            return True
+    return False 
 
 def getList(st):
     # split a string into a list

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 import lazylibrarian
-
+import shlex
 
 def now():
     dtnow = datetime.datetime.now()
@@ -93,7 +93,7 @@ def is_valid_isbn(isbn):
     return 0
 
 def is_valid_booktype(filename):
-    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
+    booktype_list = getList(lazylibrarian.EBOOK_TYPE)
     if '.' in filename:
         words = filename.split('.')
         extn = words[len(words) - 1]

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -93,6 +93,14 @@ def is_valid_isbn(isbn):
     return 0
 
 
+def getList(st):
+    # split a string into a list
+    my_splitter = shlex.shlex(st, posix=True)
+    my_splitter.whitespace += ','
+    my_splitter.whitespace_split = True
+    return list(my_splitter)
+
+
 def latinToAscii(unicrap):
     """
     From couch potato

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -88,7 +88,7 @@ def is_valid_isbn(isbn):
             if isbn[:9].isdigit():
                 return 1
             else:
-                if isbn[9] in ["X", "x"] and isbn[:8].isdigit():
+                if isbn[9] in ["Xx"] and isbn[:8].isdigit():
                     return 1
     return 0
 

--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -48,7 +48,7 @@ class GoogleBooks:
             api_strings = ['inauthor:', 'intitle:']
 
         api_hits = 0
-        logger.info('Now searching Google Books API with keyword: ' + self.name)
+        logger.debug('Now searching Google Books API with keyword: ' + self.name)
 
         for api_value in api_strings:
             startindex = 0
@@ -77,7 +77,7 @@ class GoogleBooks:
                         number_results = jsonresults['totalItems']
                         logger.debug('Searching url: ' + URL)
                         if number_results == 0:
-                            logger.info('Found no results for %s with value: %s' % (api_value, self.name))
+                            logger.warn('Found no results for %s with value: %s' % (api_value, self.name))
                             break
                         else:
                             pass
@@ -231,13 +231,13 @@ class GoogleBooks:
         logger.debug("Found %s total results" % total_count)
         logger.debug("Removed %s bad language results" % ignored)
         logger.debug("Removed %s books with no author" % no_author_count)
-        logger.info("Showing %s results for (%s) with keyword: %s" % (resultcount, api_value, authorname))
-        logger.info('The Google Books API was hit %s times for keyword %s' % (str(api_hits), self.name))
+        logger.debug("Showing %s results for (%s) with keyword: %s" % (resultcount, api_value, authorname))
+        logger.debug('The Google Books API was hit %s times for keyword %s' % (str(api_hits), self.name))
         queue.put(resultlist)
 
     def get_author_books(self, authorid=None, authorname=None, refresh=False):
 
-        logger.info('[%s] Now processing books with Google Books API' % authorname)
+        logger.debug('[%s] Now processing books with Google Books API' % authorname)
         # google doesnt like accents in author names
         aname = unidecode(u'%s' % authorname)
 
@@ -286,10 +286,10 @@ class GoogleBooks:
                     break
 
                 if number_results == 0:
-                    logger.info('Found no results for %s' % (authorname))
+                    logger.warn('Found no results for %s' % (authorname))
                     break
                 else:
-                    logger.info('Found %s results for %s' % (number_results, authorname))
+                    logger.debug('Found %s results for %s' % (number_results, authorname))
 
                 startindex = startindex + 40
 
@@ -464,21 +464,21 @@ class GoogleBooks:
                             myDB.upsert("books", newValueDict, controlValueDict)
                             logger.debug(u"book found " + bookname + " " + bookdate)
                             if not find_book_status:
-                                logger.info("[%s] Added book: %s [%s]" % (authorname, bookname, booklang))
+                                logger.debug("[%s] Added book: %s [%s]" % (authorname, bookname, booklang))
                                 added_count = added_count + 1
                             else:
                                 updated_count = updated_count + 1
-                                logger.info("[%s] Updated book: %s" % (authorname, bookname))
+                                logger.debug("[%s] Updated book: %s" % (authorname, bookname))
                         else:
                             book_ignore_count = book_ignore_count + 1
                     else:
-                        logger.info("[%s] removed book for bad characters" % (bookname))
+                        logger.debug("[%s] removed book for bad characters" % (bookname))
                         removedResults = removedResults + 1
 
         except KeyError:
             pass
 
-        logger.info('[%s] The Google Books API was hit %s times to populate book list' % (authorname, str(api_hits)))
+        logger.debug('[%s] The Google Books API was hit %s times to populate book list' % (authorname, str(api_hits)))
 
         unignoredbooks = myDB.select('SELECT COUNT(BookName) as unignored FROM books WHERE AuthorID="%s" AND Status != "Ignored"' % authorid)
         bookCount = myDB.select('SELECT COUNT(BookName) as counter FROM books WHERE AuthorID="%s"' % authorid)
@@ -638,4 +638,4 @@ class GoogleBooks:
         }
 
         myDB.upsert("books", newValueDict, controlValueDict)
-        logger.info("%s added to the books database" % bookname)
+        logger.debug("%s added to the books database" % bookname)

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -41,7 +41,7 @@ class GoodReads:
 
         url = urllib.quote_plus(authorname.encode('utf-8'))
         set_url = 'http://www.goodreads.com/search.xml?q=' + url + '&' + urllib.urlencode(self.params)
-        logger.info('Now searching GoodReads API with keyword: ' + authorname)
+        logger.debug('Now searching GoodReads API with keyword: ' + authorname)
         logger.debug('Searching for %s at: %s' % (authorname, set_url))
 
         try:
@@ -140,11 +140,11 @@ class GoodReads:
 
         except urllib2.HTTPError, err:
             if err.code == 404:
-                logger.info('Received a 404 error when searching for author')
+                logger.error('Received a 404 error when searching for author')
             if err.code == 403:
-                logger.info('Access to api is denied: usage exceeded')
+                logger.warn('Access to api is denied: usage exceeded')
             else:
-                logger.info('An unexpected error has occurred when searching for an author')
+                logger.error('An unexpected error has occurred when searching for an author')
 
         logger.debug('Found %s results with keyword: %s' % (resultcount, authorname))
         logger.debug('The GoodReads API was hit %s times for keyword %s' % (str(api_hits), authorname))
@@ -179,7 +179,7 @@ class GoodReads:
         resultxml = rootxml.getiterator('author')
 
         if not len(resultxml):
-            logger.info('No authors found with name: %s' % self.name)
+            logger.warn('No authors found with name: %s' % self.name)
         else:
             # In spite of how this looks, goodreads only returns one result, even if there are multiple matches
             # we just have to hope we get the right one. eg search for "James Lovelock" returns "James E. Lovelock"
@@ -214,10 +214,10 @@ class GoodReads:
             logger.error("Error fetching author ID: " + str(e))
 
         if not len(resultxml):
-            logger.info('No author found with ID: ' + authorid)
+            logger.warn('No author found with ID: ' + authorid)
 
         else:
-            logger.info("[%s] Processing info for authorID: %s" % (authorname, authorid))
+            logger.debug("[%s] Processing info for authorID: %s" % (authorname, authorid))
 
             # PAB added authorname to author_dict - this holds the intact name preferred by GR
             author_dict = {
@@ -266,10 +266,10 @@ class GoodReads:
         valid_langs = ([valid_lang.strip() for valid_lang in lazylibrarian.IMP_PREFLANG.split(',')])
 
         if not len(resultxml):
-            logger.info('[%s] No books found for author with ID: %s' % (authorname, authorid))
+            logger.warn('[%s] No books found for author with ID: %s' % (authorname, authorid))
 
         else:
-            logger.info("[%s] Now processing books with GoodReads API" % authorname)
+            logger.debug("[%s] Now processing books with GoodReads API" % authorname)
 
             resultsCount = 0
             removedResults = 0
@@ -476,10 +476,10 @@ class GoodReads:
                             myDB.upsert("books", newValueDict, controlValueDict)
                             logger.debug(u"book found " + book.find('title').text + " " + pubyear)
                             if not find_book_status:
-                                logger.info("[%s] Added book: %s" % (authorname, bookname))
+                                logger.debug("[%s] Added book: %s" % (authorname, bookname))
                                 added_count = added_count + 1
                             else:
-                                logger.info("[%s] Updated book: %s" % (authorname, bookname))
+                                logger.debug("[%s] Updated book: %s" % (authorname, bookname))
                                 updated_count = updated_count + 1
                         else:
                             book_ignore_count = book_ignore_count + 1
@@ -578,7 +578,7 @@ class GoodReads:
 #
         valid_langs = ([valid_lang.strip() for valid_lang in lazylibrarian.IMP_PREFLANG.split(',')])
         if bookLanguage not in valid_langs:
-            logger.info('Book %s language does not match preference' % bookname)
+            logger.debug('Book %s language does not match preference' % bookname)
 
         if (rootxml.find('./book/publication_year').text == None):
             bookdate = "0000"
@@ -635,4 +635,4 @@ class GoodReads:
 
         # print newValueDict
         myDB.upsert("books", newValueDict, controlValueDict)
-        logger.info("%s added to the books database" % bookname)
+        logger.debug("%s added to the books database" % bookname)

--- a/lazylibrarian/importer.py
+++ b/lazylibrarian/importer.py
@@ -25,10 +25,10 @@ def addAuthorToDB(authorname=None, refresh=False):
             "AuthorID":   "0: %s" % (authorname),
             "Status":       "Loading"
         }
-        logger.info("Now adding new author: %s to database" % authorname)
+        logger.debug("Now adding new author: %s to database" % authorname)
     else:
         newValueDict = {"Status": "Loading"}
-        logger.info("Now updating author: %s" % authorname)
+        logger.debug("Now updating author: %s" % authorname)
     myDB.upsert("authors", newValueDict, controlValueDict)
 
     author = GR.find_author_id()
@@ -48,7 +48,7 @@ def addAuthorToDB(authorname=None, refresh=False):
         }
         myDB.upsert("authors", newValueDict, controlValueDict)
     else:
-        logger.error("Nothing found")
+        logger.warn("Nothing found for %s" % authorname)
 
 # process books
     if lazylibrarian.BOOK_API == "GoogleBooks":
@@ -57,4 +57,4 @@ def addAuthorToDB(authorname=None, refresh=False):
     elif lazylibrarian.BOOK_API == "GoodReads":
         GR.get_author_books(authorid, authorname, refresh=refresh)
 
-    logger.info("[%s] Author update complete" % authorname)
+    logger.debug("[%s] Author update complete" % authorname)

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -372,7 +372,7 @@ def LibraryScan(dir=None):
                             "Found Language [%s] ISBN [%s]" %
                             (language, isbn))
                         # we need to add it to language cache if not already
-                        # there
+                        # there, is_valid_isbn has checked length is 10 or 13
                         if len(isbn) == 10:
                             isbnhead = isbn[0:3]
                         else:

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -94,13 +94,6 @@ def get_book_info(fname):
         n = n + 1
     return res
 
-
-def getList(st):
-    my_splitter = shlex.shlex(st, posix=True)
-    my_splitter.whitespace += ','
-    my_splitter.whitespace_split = True
-    return list(my_splitter)
-
 # PAB fuzzy search for book in library, return LL bookid if found or zero
 # if not, return bookid to more easily update status
 
@@ -255,7 +248,7 @@ def LibraryScan(dir=None):
     # with regular expression matching
     booktypes = ''
     count = -1
-    booktype_list = getList(lazylibrarian.EBOOK_TYPE)
+    booktype_list = formatter.getList(lazylibrarian.EBOOK_TYPE)
     for book_type in booktype_list:
         count += 1
         if count == 0:

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -53,7 +53,7 @@ def get_book_info(fname):
         tree = ElementTree.fromstring(txt)
         n = 0
         cfname = ""
-        if not tree:
+        if not len(tree):
             return res
         while n < len(tree[0]):
             att = str(tree[0][n].attrib)
@@ -73,7 +73,7 @@ def get_book_info(fname):
             return ""
 
     # repackage the data
-    if not tree:
+    if not len(tree):
         return res
     n = 0
     while n < len(tree[0]):

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -1,7 +1,6 @@
 import os
 import re
 import lazylibrarian
-import shlex
 from lazylibrarian import logger, database, importer, formatter
 from lazylibrarian.gr import GoodReads
 from lib.fuzzywuzzy import fuzz

--- a/lazylibrarian/logger.py
+++ b/lazylibrarian/logger.py
@@ -8,7 +8,7 @@ import lazylibrarian
 from lazylibrarian import formatter
 
 MAX_SIZE = 51200  # 5 Bytes
-MAX_FILES = 5
+MAX_FILES = 10
 
 
 # Simple rotating log handler that uses RotatingFileHandler

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -1,0 +1,137 @@
+import os
+import datetime
+import lazylibrarian
+import threading
+
+from lazylibrarian import database, logger, formatter, notifiers, common
+
+def magazineScan(thread=None):
+    # rename this thread
+    if thread == None:
+        threading.currentThread().name = "MAGAZINESCAN"
+
+    myDB = database.DBConnection()
+
+    mag_path = lazylibrarian.MAG_DEST_FOLDER
+    if '$' in mag_path:
+        mag_path = mag_path.split('$')[0]
+    
+    if lazylibrarian.MAG_RELATIVE:
+        if mag_path[0] not in '._':
+            mag_path = '_' + mag_path
+        mag_path = os.path.join(lazylibrarian.DESTINATION_DIR, mag_path).encode(lazylibrarian.SYS_ENCODING)
+    else:
+        mag_path = mag_path.encode(lazylibrarian.SYS_ENCODING)
+
+    if lazylibrarian.FULL_SCAN:
+        mags = myDB.select('select * from Issues')
+        
+        for mag in mags:
+            title = mag['Title']
+            issuedate = mag['IssueDate']
+            issuefile = mag['IssueFile']
+
+            if not issuefile and os.path.isfile(issuefile):
+                myDB.action('DELETE from Issues where issuefile="%s"' % issuefile)
+                logger.info('Issue %s - %s deleted as not found on disk' % (title, issuedate))
+                controlValueDict = {"Title": title}
+                newValueDict = {
+                    "LastAcquired": None,       # clear magazine dates
+                    "IssueDate":    None,       # we will fill them in again later
+                    "IssueStatus": "Skipped"    # assume there are no issues now
+                }
+                myDB.upsert("magazines", newValueDict, controlValueDict)
+                logger.debug('Magazine %s details reset' % title)
+                    
+    logger.info(' Checking [%s] for magazines' % mag_path)
+
+    for dirname, dirnames, filenames in os.walk(mag_path):
+      for fname in filenames[:]:
+        #if fname.endswith('.pdf'): maybe not all magazines will be pdf?
+        words = fname.split('.')
+        extn = words[len(words) - 1]
+        if extn in lazylibrarian.EBOOK_TYPE:
+            title = fname.split('-')[3]
+            title = title.split('.')[-2]
+            title = title.strip()
+            issuedate = fname.split(' ')[0]
+            issuefile = os.path.join(dirname, fname) # full path to issue.pdf
+            logger.debug("Found Issue %s" % fname)
+            
+            mtime = os.path.getmtime(issuefile)
+            iss_acquired = datetime.date.isoformat(datetime.date.fromtimestamp(mtime))
+
+            # magazines table:  Title, Frequency, Regex, Status, MagazineAdded, LastAcquired, IssueDate, IssueStatus
+            # issues table:     Title, IssueAcquired, IssueDate, IssueFile
+            
+            controlValueDict = {"Title": title}
+            
+            # is this magazine already in the database?
+            mag_entry = myDB.select('SELECT * from magazines WHERE Title="%s"' % title)
+            if not mag_entry:
+                # need to add a new magazine to the database
+                newValueDict = {
+                    "Frequency": "Monthly", # no idea really, set a default value
+                    "Regex": None,
+                    "Status": "Active",
+                    "MagazineAdded": None,
+                    "LastAcquired": None,
+                    "IssueDate": None,
+                    "IssueStatus": "Skipped"
+                }
+                logger.debug("Adding magazine %s" % title)
+                myDB.upsert("magazines", newValueDict, controlValueDict)
+                lastacquired = None
+                magissuedate = None
+                magazineadded = None
+            else:
+                maglastacquired = mag_entry[0]['LastAcquired']
+                magissuedate = mag_entry[0]['IssueDate']
+                magazineadded = mag_entry[0]['MagazineAdded']
+            
+            # is this issue already in the database?
+            controlValueDict = {"Title": title, "IssueDate": issuedate}
+            iss_entry = myDB.select('SELECT * from issues WHERE Title="%s" and IssueDate="%s"' % (title, issuedate))
+            if not iss_entry:
+                newValueDict = {
+                    "IssueAcquired": iss_acquired,
+                    "IssueFile": issuefile
+                }
+                logger.debug("Adding issue %s %s" % (title, issuedate))
+                myDB.upsert("Issues", newValueDict, controlValueDict)
+               
+            # see if this issues date values are useful
+            # if its a new magazine, magazineadded,magissuedate,lastacquired are all None
+            # if magazineadded is NOT None, but the others are, we've deleted one or more issues
+            # so the most recent dates may be wrong and need to be updated.
+            # Set magazine_issuedate to issuedate of most recent issue we have
+            # Set magazine_added to acquired date of earliest issue we have
+            # Set magazine_lastacquired to acquired date of most recent issue we have
+            # acquired dates are read from magazine file timestamps
+            if magazineadded == None: # new magazine, this might be the only issue
+                controlValueDict = {"Title": title}
+                newValueDict = {
+                    "MagazineAdded": iss_acquired,
+                    "LastAcquired": iss_acquired,       
+                    "IssueDate":    issuedate,       
+                    "IssueStatus": "Open"    
+                }
+                myDB.upsert("magazines", newValueDict, controlValueDict)
+            else:
+                if iss_acquired < magazineadded:
+                    controlValueDict = {"Title": title}
+                    newValueDict = {"MagazineAdded": iss_acquired}
+                    myDB.upsert("magazines", newValueDict, controlValueDict)
+                if maglastacquired == None or iss_acquired > maglastacquired:
+                    controlValueDict = {"Title": title}
+                    newValueDict = {"LastAcquired": iss_acquired}
+                    myDB.upsert("magazines", newValueDict, controlValueDict)
+                if magissuedate == None or issuedate > magissuedate:
+                    controlValueDict = {"Title": title}
+                    newValueDict = {"IssueDate": issuedate}
+                    myDB.upsert("magazines", newValueDict, controlValueDict)               
+
+    magcount = myDB.action("select count(*) from magazines").fetchone()
+    isscount = myDB.action("select count(*) from issues").fetchone()
+    
+    logger.info("Magazine scan complete, found %s magazines, %s issues" % (magcount['count(*)'], isscount['count(*)']))

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -45,12 +45,13 @@ def magazineScan(thread=None):
                     
     logger.info(' Checking [%s] for magazines' % mag_path)
 
+    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
     for dirname, dirnames, filenames in os.walk(mag_path):
       for fname in filenames[:]:
         #if fname.endswith('.pdf'): maybe not all magazines will be pdf?
         words = fname.split('.')
         extn = words[len(words) - 1]
-        if extn in lazylibrarian.EBOOK_TYPE:
+        if extn in booktype_list:
             title = fname.split('-')[3]
             title = title.split('.')[-2]
             title = title.strip()

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -45,20 +45,21 @@ def magazineScan(thread=None):
                     
     logger.info(' Checking [%s] for magazines' % mag_path)
 
-    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
     for dirname, dirnames, filenames in os.walk(mag_path):
       for fname in filenames[:]:
         #if fname.endswith('.pdf'): maybe not all magazines will be pdf?
-        words = fname.split('.')
-        extn = words[len(words) - 1]
-        if extn in booktype_list:
-            title = fname.split('-')[3]
-            title = title.split('.')[-2]
-            title = title.strip()
-            issuedate = fname.split(' ')[0]
-            issuefile = os.path.join(dirname, fname) # full path to issue.pdf
-            logger.debug("Found Issue %s" % fname)
-            
+        if formatter.is_valid_booktype(fname):
+            try:
+                title = fname.split('-')[3]
+                title = title.split('.')[-2]
+                title = title.strip()
+                issuedate = fname.split(' ')[0]
+                issuefile = os.path.join(dirname, fname) # full path to issue.pdf
+                logger.debug("Found Issue %s" % fname)
+            except:
+                logger.debug("Invalid name format for %s" % fname)
+                continue
+                
             mtime = os.path.getmtime(issuefile)
             iss_acquired = datetime.date.isoformat(datetime.date.fromtimestamp(mtime))
 

--- a/lazylibrarian/notifiers/pushover.py
+++ b/lazylibrarian/notifiers/pushover.py
@@ -33,7 +33,7 @@ from lazylibrarian.common import notifyStrings, NOTIFY_SNATCH, NOTIFY_DOWNLOAD
 class PushoverNotifier:
 
     def _sendPushover(self, message=None, event=None, pushover_apitoken=None, pushover_keys=None,
-                      notificationType=None, method=None, force=False):
+                      pushover_device=None, notificationType=None, method=None, force=False):
 
         if not lazylibrarian.USE_PUSHOVER and not force:
             return False
@@ -42,44 +42,41 @@ class PushoverNotifier:
             pushover_apitoken = lazylibrarian.PUSHOVER_APITOKEN
         if pushover_keys == None:
             pushover_keys = lazylibrarian.PUSHOVER_KEYS
-        method = 'POST'
-        if method == 'POST':
-            uri = '/api/pushes'
-        else:
-            uri = '/api/keys'
-
-        logger.debug("Pushover event: " + str(event))
-        logger.debug("Pushover message: " + str(message))
-        logger.debug("Pushover api: " + str(pushover_apitoken))
-        logger.debug("Pushover keys: " + str(pushover_keys))
-        logger.debug("Pushover notification type: " + str(notificationType))
-
-        http_handler = HTTPSConnection('api.pushover.net')
-
+        if pushover_device == None:
+            pushover_device = lazylibrarian.PUSHOVER_DEVICE
+        if method == None:
+            method = 'POST'
         if notificationType == None:
             testMessage = True
-            try:
-                logger.debug("Testing Pushover authentication and retrieving the device list.")
-                http_handler.request(method, uri, None, headers={'Authorization': 'Basic %s:' % authString})
-            except (SSLError, HTTPException):
-                logger.error("Pushover notification failed.")
-                return False
+            uri = "/1/users/validate.json"
+            logger.debug("Testing Pushover authentication and retrieving the device list.")
         else:
             testMessage = False
-            try:
-                data = {'token': lazylibrarian.PUSHOVER_APITOKEN,
-                        'user': pushover_keys,
-                        'title': event.encode('utf-8'),
-                        'message': message.encode("utf-8"),
-                        'priority': lazylibrarian.PUSHOVER_PRIORITY}
-                http_handler.request("POST",
-                                     "/1/messages.json",
-                                     headers={'Content-type': "application/x-www-form-urlencoded"},
-                                     body=urlencode(data))
-                pass
-            except Exception, e:
-                logger.error(str(e))
-                return False
+            uri = "/1/messages.json"
+            logger.debug("Pushover event: " + str(event))
+            logger.debug("Pushover message: " + str(message))
+            logger.debug("Pushover api: " + str())
+            logger.debug("Pushover keys: " + str(pushover_keys))
+            logger.debug("Pushover device: " + str(pushover_device))
+            logger.debug("Pushover notification type: " + str(notificationType))
+
+        http_handler = HTTPSConnection('api.pushover.net')
+        
+        try:
+            data = {'token': pushover_apitoken,
+                    'user': pushover_keys,
+                    'title': event.encode('utf-8'),
+                    'message': message.encode("utf-8"),
+                    'device': pushover_device,
+                    'priority': lazylibrarian.PUSHOVER_PRIORITY}
+            http_handler.request("POST",
+                                 uri,
+                                 headers={'Content-type': "application/x-www-form-urlencoded"},
+                                 body=urlencode(data))
+            pass
+        except Exception, e:
+            logger.error(str(e))
+            return False
 
         response = http_handler.getresponse()
         request_body = response.read()
@@ -88,19 +85,22 @@ class PushoverNotifier:
         logger.debug("Pushover Reason: %s" % response.reason)
         if request_status == 200:
             if testMessage:
-                return request_body
+                logger.debug(request_body)
+                if 'devices' in request_body:
+                    return "Devices: %s" % request_body.split('[')[1].split(']')[0]
+                else:
+                    return request_body  
             else:
-                logger.debug("Pushover notifications sent.")
                 return True
         elif request_status >= 400 and request_status < 500:
-            logger.error("Pushover reqeust failed: %s" % response.reason)
+            logger.error("Pushover request failed: %s" % response.reason)
             return False
         else:
-            logger.error("Pushover notification failed.")
+            logger.error("Pushover notification failed: %s" % request_status)
             return False
 
     def _notify(self, message=None, event=None, pushover_apitoken=None, pushover_keys=None,
-                notificationType=None, method=None, force=False):
+                pushover_device=None, notificationType=None, method=None, force=False):
         """
         Sends a pushover notification based on the provided info or LL config
 
@@ -117,10 +117,9 @@ class PushoverNotifier:
         if not lazylibrarian.USE_PUSHOVER and not force:
             return False
 
-        logger.debug("Pushover: Sending notification for " + str(message))
+        logger.debug("Pushover: Sending notification " + str(message))
 
-        self._sendPushover(message, event, pushover_apitoken, pushover_keys, notificationType, method)
-        return True
+        return self._sendPushover(message, event, pushover_apitoken, pushover_keys, pushover_device, notificationType, method)
 
 #
 # Public functions
@@ -128,14 +127,14 @@ class PushoverNotifier:
 
     def notify_snatch(self, title):
         if lazylibrarian.PUSHOVER_ONSNATCH:
-            self._notify(message=title, event=notifyStrings[NOTIFY_SNATCH], notificationType='note', method='POST')
+            self._notify(message=title, event=notifyStrings[NOTIFY_SNATCH], notificationType='note')
 
     def notify_download(self, title):
         if lazylibrarian.PUSHOVER_ONDOWNLOAD:
-            self._notify(message=title, event=notifyStrings[NOTIFY_DOWNLOAD], notificationType='note', method='POST')
+            self._notify(message=title, event=notifyStrings[NOTIFY_DOWNLOAD], notificationType='note')
 
-    def test_notify(self, apitoken, title="Test"):
-        return self._sendPushover("This is a test notification from LazyLibrarian", title, apitoken)
+    def test_notify(self, title="Test"):
+        return self._notify(message="This is a test notification from LazyLibrarian", event=title, notificationType=None)
 
     def update_library(self, showName=None):
         pass

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -39,7 +39,7 @@ def processDir():
         for book in snatched:
             if book['NZBtitle'] in downloads:
                 pp_path = os.path.join(processpath, book['NZBtitle'])
-                logger.info('Found book/mag folder %s.' % pp_path)
+                logger.debug('Found book/mag folder %s.' % pp_path)
 
                 data = myDB.select('SELECT * from books WHERE BookID="%s"' % book['BookID'])
                 if data:
@@ -72,10 +72,10 @@ def processDir():
                         global_name = lazylibrarian.MAG_DEST_FILE.replace('$IssueDate', book['AuxInfo']).replace('$Title', book['BookID'])
                         # global_name = book['AuxInfo']+' - '+title
                     else:
-                        logger.info("Snatched magazine %s is not in download directory" % (book['BookID']))
+                        logger.debug("Snatched magazine %s is not in download directory" % (book['BookID']))
                         continue                    
             else:
-                logger.info("Snatched NZB %s is not in download directory" % (book['NZBtitle']))
+                logger.debug("Snatched NZB %s is not in download directory" % (book['NZBtitle']))
                 continue
 
             dic = {'<': '', '>': '', '...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': '', '*': '', ':': '', ';': '', '\'': ''}
@@ -166,7 +166,7 @@ def processDir():
                             logger.error('Postprocessing for %s has failed.' % global_name)
                             logger.error('Warning - Residual files remain in %s' % pp_path)
         if ppcount:
-            logger.info('%s books/mags are downloaded and processed.' % ppcount)
+            logger.info('%s books/mags have been processed.' % ppcount)
         else:
             logger.info('No snatched books/mags have been found')
 
@@ -230,7 +230,7 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
 
     # check we got a book in the downloaded files
     pp = False
-    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
+    booktype_list = formatter.getList(lazylibrarian.EBOOK_TYPE)
     for bookfile in os.listdir(pp_path):
         if ((str(bookfile).split('.')[-1]) in booktype_list):    
             pp = True
@@ -251,12 +251,12 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
             shutil.copytree(pp_path, dest_path)
             logger.debug('Successfully copied %s to %s.' % (pp_path, dest_path))
         elif lazylibrarian.DOWNLOAD_DIR == pp_path:
-            booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
+            booktype_list = formatter.getList(lazylibrarian.EBOOK_TYPE)
             for file3 in os.listdir(pp_path):
                 if ((str(file3).split('.')[-1]) in booktype_list):
                     bookID = str(file3).split("LL.(")[1].split(")")[0]
                     if bookID == book_id:
-                        logger.info('Processing %s' % bookID)
+                        logger.debug('Processing %s' % bookID)
                         if not os.path.exists(dest_path):
                             try:
                                 os.makedirs(dest_path)
@@ -273,7 +273,7 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
         pp = True
 
         # try and rename the actual book file & remove non-book files
-        booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
+        booktype_list = formatter.getList(lazylibrarian.EBOOK_TYPE)
         for file2 in os.listdir(dest_path):
             #logger.debug('file extension: ' + str(file2).split('.')[-1])
             if ((file2.lower().find(".jpg") <= 0) & (file2.lower().find(".opf") <= 0)):
@@ -288,8 +288,8 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
         except Exception, e:
             logger.debug("Could not chmod path: " + str(dest_path))
     except OSError, e:
-        logger.info('Could not create destination folder or rename the downloaded ebook. Check permissions of: ' + lazylibrarian.DESTINATION_DIR)
-        logger.info(str(e))
+        logger.error('Could not create destination folder or rename the downloaded ebook. Check permissions of: ' + lazylibrarian.DESTINATION_DIR)
+        logger.error(str(e))
         pp = False
     return pp
 
@@ -300,7 +300,7 @@ def processAutoAdd(src_path=None):
     logger.debug('AutoAdd - Attempt to copy from [%s] to [%s]' % (src_path, autoadddir))
 
     if not os.path.exists(autoadddir):
-        logger.info('AutoAdd directory [%s] is missing or not set - cannot perform autoadd copy' % autoadddir)
+        logger.error('AutoAdd directory [%s] is missing or not set - cannot perform autoadd copy' % autoadddir)
         return False
     else:
         # Now try and copy all the book files into a single dir.
@@ -343,7 +343,7 @@ def processIMG(dest_path=None, bookimg=None, global_name=None):
             try:
                 os.chmod(coverpath, 0777)
             except Exception, e:
-                logger.info("Could not chmod path: " + str(coverpath))
+                logger.error("Could not chmod path: " + str(coverpath))
 
     except (IOError, EOFError), e:
         logger.error('Error fetching cover from url: %s, %s' % (bookimg, e))
@@ -390,7 +390,7 @@ def processOPF(dest_path=None, authorname=None, bookname=None, bookisbn=None, bo
         try:
             os.chmod(opfpath, 0777)
         except Exception, e:
-            logger.info("Could not chmod path: " + str(opfpath))
+            logger.error("Could not chmod path: " + str(opfpath))
 
         logger.debug('Saved metadata to: ' + opfpath)
     else:

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -21,7 +21,21 @@ def processAlternate(source_dir=None):
         return
     new_book = book_file(source_dir)
     if new_book:
-        metadata = librarysync.get_book_info(new_book)
+        # see if there is a metadata file in this folder with the info we need
+        metafile = librarysync.opf_file(source_dir)
+        try:
+            metadata = librarysync.get_book_info(metafile)
+        except:
+            metadata = {}
+        if 'title' in metadata and 'creator' in metadata:
+            authorname = metadata['creator']
+            bookname = metadata['title']
+        # if not, try to get metadata from the book file
+        else:            
+            try:
+                metadata = librarysync.get_book_info(new_book)
+            except:
+                metadata = {}
         if 'title' in metadata and 'creator' in metadata:
             authorname = metadata['creator']
             bookname = metadata['title']
@@ -32,7 +46,7 @@ def processAlternate(source_dir=None):
             else:
                 logger.warn("Book %s by %s not found in database" % (bookname, authorname))
         else:
-            logger.warn('Book %s has no embedded metadata, unable to import' % new_book)
+            logger.warn('Book %s has no metadata, unable to import' % new_book)
     else:
         logger.warn("No book found in %s" % source_dir)
 
@@ -213,8 +227,9 @@ def book_file(search_dir=None):
     if search_dir and os.path.isdir(search_dir):
         for fname in os.listdir(search_dir):
             if formatter.is_valid_booktype(fname):
-                return os.path.join(search_dir, fname)
+                return os.path.join(search_dir, fname).encode(lazylibrarian.SYS_ENCODING)
     return ""                           
+
 
 def processExtras(myDB=None, dest_path=None, global_name=None, data=None):
     # given book data, handle calibre autoadd, book image, opf,

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -13,6 +13,12 @@ from lazylibrarian import database, logger, formatter, notifiers, common, librar
 
 def processAlternate(source_dir=None):
 # import a book from an alternate directory
+    if source_dir == None or source_dir == "":
+        logger.warn('Alternate directory must not be empty')
+        return
+    if source_dir == lazylibrarian.DESTINATION_DIR:
+        logger.warn('Alternate directory must not be the same as destination')
+        return
     new_book = book_file(source_dir)
     if new_book:
         metadata = librarysync.get_book_info(new_book)

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -9,7 +9,23 @@ from urllib import FancyURLopener
 
 import lazylibrarian
 
-from lazylibrarian import database, logger, formatter, notifiers, common
+from lazylibrarian import database, logger, formatter, notifiers, common, librarysync
+
+def processAlternate(source_dir=None):
+# import a book from an alternate directory
+    new_book = book_file(source_dir)
+    if new_book:
+        metadata = librarysync.get_book_info(new_book)
+        authorname = metadata['creator']
+        bookname = metadata['title']
+        myDB = database.DBConnection()
+        bookid = librarysync.find_book_in_db(myDB, authorname, bookname)
+        if bookid:
+            import_book(source_dir, bookid)
+        else:
+            logger.warn("Book %s by %s not found in database" % (bookname, authorname))
+    else:
+        logger.warn("No book found in %s" % source_dir)
 
 def processDir():
     # rename this thread

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -173,14 +173,10 @@ def processDir():
 def book_file(search_dir=None):
     # find a book file in this directory, any book will do
     # return full pathname of book, or empty string if no book found
-    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
     if search_dir and os.path.isdir(search_dir):
         for fname in os.listdir(search_dir):
-            if '.' in fname:
-                words = fname.split('.')
-                extn = words[len(words) - 1]
-                if extn in booktype_list:
-                    return os.path.join(search_dir, fname)
+            if formatter.is_valid_booktype(fname):
+                return os.path.join(search_dir, fname)
     return ""                           
 
 def processExtras(myDB=None, dest_path=None, global_name=None, data=None):

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -22,14 +22,17 @@ def processAlternate(source_dir=None):
     new_book = book_file(source_dir)
     if new_book:
         metadata = librarysync.get_book_info(new_book)
-        authorname = metadata['creator']
-        bookname = metadata['title']
-        myDB = database.DBConnection()
-        bookid = librarysync.find_book_in_db(myDB, authorname, bookname)
-        if bookid:
-            import_book(source_dir, bookid)
+        if 'title' in metadata and 'creator' in metadata:
+            authorname = metadata['creator']
+            bookname = metadata['title']
+            myDB = database.DBConnection()
+            bookid = librarysync.find_book_in_db(myDB, authorname, bookname)
+            if bookid:
+                import_book(source_dir, bookid)
+            else:
+                logger.warn("Book %s by %s not found in database" % (bookname, authorname))
         else:
-            logger.warn("Book %s by %s not found in database" % (bookname, authorname))
+            logger.warn('Book %s has no embedded metadata, unable to import' % new_book)
     else:
         logger.warn("No book found in %s" % source_dir)
 

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -173,12 +173,13 @@ def processDir():
 def book_file(search_dir=None):
     # find a book file in this directory, any book will do
     # return full pathname of book, or empty string if no book found
+    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
     if search_dir and os.path.isdir(search_dir):
         for fname in os.listdir(search_dir):
             if '.' in fname:
                 words = fname.split('.')
                 extn = words[len(words) - 1]
-                if extn in lazylibrarian.EBOOK_TYPE:
+                if extn in booktype_list:
                     return os.path.join(search_dir, fname)
     return ""                           
 
@@ -233,8 +234,9 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
 
     # check we got a book in the downloaded files
     pp = False
+    booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
     for bookfile in os.listdir(pp_path):
-        if ((str(bookfile).split('.')[-1]) in lazylibrarian.EBOOK_TYPE):    
+        if ((str(bookfile).split('.')[-1]) in booktype_list):    
             pp = True
     if pp == False:
         # no book found in a format we wanted. Leave for the user to delete or convert manually
@@ -253,8 +255,9 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
             shutil.copytree(pp_path, dest_path)
             logger.debug('Successfully copied %s to %s.' % (pp_path, dest_path))
         elif lazylibrarian.DOWNLOAD_DIR == pp_path:
+            booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
             for file3 in os.listdir(pp_path):
-                if ((str(file3).split('.')[-1]) in lazylibrarian.EBOOK_TYPE):
+                if ((str(file3).split('.')[-1]) in booktype_list):
                     bookID = str(file3).split("LL.(")[1].split(")")[0]
                     if bookID == book_id:
                         logger.info('Processing %s' % bookID)
@@ -274,10 +277,11 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
         pp = True
 
         # try and rename the actual book file & remove non-book files
+        booktype_list = formatter.getlist(lazylibrarian.EBOOK_TYPE)
         for file2 in os.listdir(dest_path):
             #logger.debug('file extension: ' + str(file2).split('.')[-1])
             if ((file2.lower().find(".jpg") <= 0) & (file2.lower().find(".opf") <= 0)):
-                if ((str(file2).split('.')[-1]) not in lazylibrarian.EBOOK_TYPE):
+                if ((str(file2).split('.')[-1]) not in booktype_list):
                     logger.debug('Removing unwanted file: %s' % str(file2))
                     os.remove(os.path.join(dest_path, file2))
                 else:

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -11,7 +11,6 @@ import lazylibrarian
 
 from lazylibrarian import database, logger, formatter, notifiers, common
 
-
 def processDir():
     # rename this thread
     threading.currentThread().name = "POSTPROCESS"
@@ -26,7 +25,8 @@ def processDir():
         downloads = os.listdir(processpath)
     except OSError:
         logger.error('Could not access [%s] directory ' % processpath)
-
+        return False
+        
     myDB = database.DBConnection()
     snatched = myDB.select('SELECT * from wanted WHERE Status="Snatched"')
 
@@ -39,60 +39,51 @@ def processDir():
         for book in snatched:
             if book['NZBtitle'] in downloads:
                 pp_path = os.path.join(processpath, book['NZBtitle'])
-                logger.info('Found folder %s.' % pp_path)
+                logger.info('Found book/mag folder %s.' % pp_path)
 
                 data = myDB.select('SELECT * from books WHERE BookID="%s"' % book['BookID'])
                 if data:
-                    for metadata in data:
-                        authorname = metadata['AuthorName']
-                        #authorimg = metadata['AuthorLink']
-                        bookname = metadata['BookName']
-                        bookdesc = metadata['BookDesc']
-                        bookisbn = metadata['BookIsbn']
-                        #bookrate = metadata['BookRate']
-                        bookimg = metadata['BookImg']
-                        #bookpage = metadata['BookPages']
-                        #booklink = metadata['BookLink']
-                        bookdate = metadata['BookDate']
-                        booklang = metadata['BookLang']
-                        bookpub = metadata['BookPub']
-
+                    authorname = data[0]['AuthorName']
+                    bookname = data[0]['BookName']
+                    
                     # Default destination path, should be allowed change per config file.
                     dest_path = lazylibrarian.EBOOK_DEST_FOLDER.replace('$Author', authorname).replace('$Title', bookname)
-                    # dest_path = authorname+'/'+bookname
                     global_name = lazylibrarian.EBOOK_DEST_FILE.replace('$Author', authorname).replace('$Title', bookname)
+                    # dest_path = authorname+'/'+bookname
                     # global_name = bookname + ' - ' + authorname
+                    dest_path = os.path.join(lazylibrarian.DESTINATION_DIR, dest_path).encode(lazylibrarian.SYS_ENCODING)
                 else:
                     data = myDB.select('SELECT * from magazines WHERE Title="%s"' % book['BookID'])
-                    for metadata in data:
-                        title = metadata['Title']
-                    # AuxInfo was added for magazine release date, normally housed in 'magazines' but if multiple
-                    # files are downloading, there will be an error in post-processing, trying to go to the
-                    # same directory.
-                    dest_path = lazylibrarian.MAG_DEST_FOLDER.replace('$IssueDate', book['AuxInfo']).replace('$Title', title)
-                    # dest_path = '_Magazines/'+title+'/'+book['AuxInfo']
-                    authorname = None
-                    bookname = None
-                    global_name = lazylibrarian.MAG_DEST_FILE.replace('$IssueDate', book['AuxInfo']).replace('$Title', title)
-                    # global_name = book['AuxInfo']+' - '+title
+                    if data:
+                        # AuxInfo was added for magazine release date, normally housed in 'magazines' but if multiple
+                        # files are downloading, there will be an error in post-processing, trying to go to the
+                        # same directory.
+                        mostrecentissue = data[0]['IssueDate'] # keep this for processing issues arriving out of order
+                        dest_path = lazylibrarian.MAG_DEST_FOLDER.replace('$IssueDate', book['AuxInfo']).replace('$Title', book['BookID'])
+                        # dest_path = '_Magazines/'+title+'/'+book['AuxInfo']
+                        if lazylibrarian.MAG_RELATIVE:
+                            if dest_path[0] not in '._':
+                                dest_path = '_' + dest_path
+                            dest_path = os.path.join(lazylibrarian.DESTINATION_DIR, dest_path).encode(lazylibrarian.SYS_ENCODING)
+                        else:
+                            dest_path = dest_path.encode(lazylibrarian.SYS_ENCODING)
+                        authorname = None
+                        bookname = None
+                        global_name = lazylibrarian.MAG_DEST_FILE.replace('$IssueDate', book['AuxInfo']).replace('$Title', book['BookID'])
+                        # global_name = book['AuxInfo']+' - '+title
+                    else:
+                        logger.info("Snatched magazine %s is not in download directory" % (book['BookID']))
+                        continue                    
             else:
                 logger.info("Snatched NZB %s is not in download directory" % (book['NZBtitle']))
                 continue
 
-            try:
-                if lazylibrarian.MAG_RELATIVE:
-                    if dest_path[0] not in '._':
-                        dest_path = '_' + dest_path
-                    post_dir = os.path.join(lazylibrarian.DESTINATION_DIR, dest_path).encode(lazylibrarian.SYS_ENCODING)
-                else:
-                    post_dir = dest_path.encode(lazylibrarian.SYS_ENCODING)
-                os.chmod(post_dir, 0777)
-            except Exception, e:
-                logger.debug("Could not chmod post-process directory: " + str(post_dir))
-
             dic = {'<': '', '>': '', '...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': '', '*': '', ':': '', ';': '', '\'': ''}
             dest_path = formatter.latinToAscii(formatter.replace_all(dest_path, dic))
-            dest_path = os.path.join(lazylibrarian.DESTINATION_DIR, dest_path).encode(lazylibrarian.SYS_ENCODING)
+            try:
+                os.chmod(dest_path, 0777)
+            except Exception, e:
+                logger.debug("Could not chmod post-process directory: " + str(dest_path))
 
             processBook = processDestination(pp_path, dest_path, authorname, bookname, global_name, book['BookID'])
 
@@ -100,77 +91,57 @@ def processDir():
 
                 ppcount = ppcount + 1
 
-                # If you use auto add by Calibre you need the book in a single directory, not nested
-                # So take the file you Copied/Moved to Dest_path and copy it to a Calibre auto add folder.
-                if lazylibrarian.IMP_AUTOADD:
-                    processAutoAdd(dest_path)
-
                 # update nzbs
                 controlValueDict = {"NZBurl": book['NZBurl']}
-                newValueDict = {"Status": "Processed"}
+                newValueDict = {"Status": "Processed", "NZBDate": formatter.today()} # say when we processed it
                 myDB.upsert("wanted", newValueDict, controlValueDict)
-
-                # try image
-                if bookname is not None:
-                    processIMG(dest_path, bookimg, global_name)
-
-                    # try metadata
-                    processOPF(dest_path, authorname, bookname, bookisbn, book['BookID'], bookpub, bookdate, bookdesc, booklang, global_name)
-
-                    # update books
-                    controlValueDict = {"BookID": book['BookID']}
-                    newValueDict = {"Status": "Open"}
-                    myDB.upsert("books", newValueDict, controlValueDict)
-
-                    # update authors
-                    query = 'SELECT COUNT(*) FROM books WHERE AuthorName="%s" AND (Status="Have" OR Status="Open")' % authorname
-                    countbooks = myDB.action(query).fetchone()
-                    havebooks = int(countbooks[0])
-                    controlValueDict = {"AuthorName": authorname}
-                    newValueDict = {"HaveBooks": havebooks}
-                    author_query = 'SELECT * FROM authors WHERE AuthorName="%s"' % authorname
-                    countauthor = myDB.action(author_query).fetchone()
-                    if countauthor:
-                        myDB.upsert("authors", newValueDict, controlValueDict)
-
-                else:
+                    
+                if bookname is not None: # it's a book, if None it's a magazine
+                    processExtras(myDB, dest_path, global_name, data)
+                else: 
                     # update mags
                     controlValueDict = {"Title": book['BookID']}
-                    newValueDict = {"LastAcquired": formatter.today(), "IssueDate": book['AuxInfo'], "IssueStatus": "Open"}
+                    if mostrecentissue > book['AuxInfo']: # check this in case processing issues arriving out of order
+                        newValueDict = {"LastAcquired": formatter.today(), "IssueStatus": "Open"}
+                    else:    
+                        newValueDict = {"IssueDate": book['AuxInfo'], "LastAcquired": formatter.today(), "IssueStatus": "Open"}
                     myDB.upsert("magazines", newValueDict, controlValueDict)
-                    
+                    # dest_path is where we put the magazine after processing, but we don't have the full filename
+                    # so look for any "book" in that directory
+                    dest_file = book_file(dest_path)
+                    controlValueDict = {"Title": book['BookID'], "IssueDate": book['AuxInfo']}
+                    newValueDict = {"IssueAcquired": formatter.today(), "IssueFile": dest_file}
+                    myDB.upsert("issues", newValueDict, controlValueDict)
+                                    
                 logger.info('Successfully processed: %s' % global_name)
                 notifiers.notify_download(formatter.latinToAscii(global_name) + ' at ' + formatter.now())
             else:
-                logger.error('Postprocessing for %s has failed. Warning - AutoAdd will be repeated' % global_name)
-
+                logger.error('Postprocessing for %s has failed.' % global_name)
+                logger.error('Warning - Residual files remain in %s' % pp_path)
+        #
+        # TODO Seems to be duplication here. Can we just scan once for snatched books 
+        # instead of scan for snatched and then scan for directories with "LL.(bookID)" in?
+        # Should there be any directories with "LL.(bookID)" that aren't in snatched?
+        # Maybe this was put in for manually downloaded books?
+        #  
+        downloads = os.listdir(processpath) # check in case we processed/deleted some above      
         for directory in downloads:
             if "LL.(" in directory:
                 bookID = str(directory).split("LL.(")[1].split(")")[0]
                 logger.debug("Book with id: " + str(bookID) + " is in downloads")
                 pp_path = os.path.join(processpath, directory)
 
-                if os.path.isfile(pp_path):
-                    pp_path = os.path.join(processpath)
+                if os.path.isfile(pp_path): # ?? what is this supposed to do
+                    pp_path = os.path.join(processpath) # this is missing a parameter, join what?
 
-                if (os.path.exists(pp_path)):
-                    logger.debug('Found folder %s.' % pp_path)
+                if (os.path.isdir(pp_path)):
+                    logger.debug('Found LL folder %s.' % pp_path)
 
                     data = myDB.select('SELECT * from books WHERE BookID="%s"' % bookID)
-                    for metadata in data:
-                        authorname = metadata['AuthorName']
-                        authorimg = metadata['AuthorLink']
-                        bookname = metadata['BookName']
-                        bookdesc = metadata['BookDesc']
-                        bookisbn = metadata['BookIsbn']
-                        bookrate = metadata['BookRate']
-                        bookimg = metadata['BookImg']
-                        bookpage = metadata['BookPages']
-                        booklink = metadata['BookLink']
-                        bookdate = metadata['BookDate']
-                        booklang = metadata['BookLang']
-                        bookpub = metadata['BookPub']
-
+                    if data:
+                        authorname = data[0]['AuthorName']
+                        bookname = data[0]['BookName']
+                        
                         try:
                             auth_dir = os.path.join(lazylibrarian.DESTINATION_DIR, authorname).encode(lazylibrarian.SYS_ENCODING)
                             os.chmod(auth_dir, 0777)
@@ -185,64 +156,96 @@ def processDir():
                         processBook = processDestination(pp_path, dest_path, authorname, bookname, global_name, bookID)
 
                         if processBook:
-
-                            ppcount = ppcount + 1
-
-                            # If you use auto add by Calibre you need the book in a single directory, not nested
-                            # So take the file you Copied/Moved to Dest_path and copy it to a Calibre auto add folder.
-                            if lazylibrarian.IMP_AUTOADD:
-                                processAutoAdd(dest_path)
-
                             # update nzbs
-                            controlValueDict = {"NZBurl": directory}
-                            newValueDict = {"Status": "Processed"}
-                            myDB.upsert("wanted", newValueDict, controlValueDict)
-
-                            # try image
-                            if bookname is not None:
-                                processIMG(dest_path, bookimg, global_name)
-
-                            # try metadata
-                            processOPF(dest_path, authorname, bookname, bookisbn, bookID, bookpub, bookdate, bookdesc, booklang, global_name)
-
-                            # update books
                             controlValueDict = {"BookID": bookID}
-                            newValueDict = {"Status": "Open"}
-                            myDB.upsert("books", newValueDict, controlValueDict)
-
-                            # update authors
-                            query = 'SELECT COUNT(*) FROM books WHERE AuthorName="%s" AND (Status="Have" OR Status="Open")' % authorname
-                            countbooks = myDB.action(query).fetchone()
-                            havebooks = int(countbooks[0])
-                            controlValueDict = {"AuthorName": authorname}
-                            newValueDict = {"HaveBooks": havebooks}
-                            author_query = 'SELECT * FROM authors WHERE AuthorName="%s"' % authorname
-                            countauthor = myDB.action(author_query).fetchone()
-                            if countauthor:
-                                myDB.upsert("authors", newValueDict, controlValueDict)
-
+                            newValueDict = {"Status": "Processed", "NZBDate": formatter.today()} # say when we processed it
+                            myDB.upsert("wanted", newValueDict, controlValueDict)
+                            ppcount = ppcount + 1
+                            processExtras(myDB, dest_path, global_name, data)
+                        else:
+                            logger.error('Postprocessing for %s has failed.' % global_name)
+                            logger.error('Warning - Residual files remain in %s' % pp_path)
         if ppcount:
-            logger.debug('%s books are downloaded and processed.' % ppcount)
+            logger.info('%s books/mags are downloaded and processed.' % ppcount)
         else:
-            logger.debug('No snatched books have been found')
+            logger.info('No snatched books/mags have been found')
 
+def book_file(search_dir=None):
+    # find a book file in this directory, any book will do
+    # return full pathname of book, or empty string if no book found
+    if search_dir and os.path.isdir(search_dir):
+        for fname in os.listdir(search_dir):
+            if '.' in fname:
+                words = fname.split('.')
+                extn = words[len(words) - 1]
+                if extn in lazylibrarian.EBOOK_TYPE:
+                    return os.path.join(search_dir, fname)
+    return ""                           
 
+def processExtras(myDB=None, dest_path=None, global_name=None, data=None):
+    # given book data, handle calibre autoadd, book image, opf,
+    # and update author and book counts
+    authorname = data[0]['AuthorName']
+    bookid = data[0]['BookID']
+    bookname = data[0]['BookName']
+    bookdesc = data[0]['BookDesc']
+    bookisbn = data[0]['BookIsbn']
+    bookimg = data[0]['BookImg']
+    bookdate = data[0]['BookDate']
+    booklang = data[0]['BookLang']
+    bookpub = data[0]['BookPub']
+
+    # If you use auto add by Calibre you need the book in a single directory, not nested
+    # So take the file you Copied/Moved to Dest_path and copy it to a Calibre auto add folder.
+    if lazylibrarian.IMP_AUTOADD:
+        processAutoAdd(dest_path)
+                
+    # try image
+    processIMG(dest_path, bookimg, global_name)
+
+    # try metadata
+    processOPF(dest_path, authorname, bookname, bookisbn, bookid, bookpub, bookdate, bookdesc, booklang, global_name)
+
+    # update books
+    # dest_path is where we put the book after processing, but we don't have the full filename
+    # we don't keep the extension, so look for any "book" in that directory
+    dest_file = book_file(dest_path)
+    controlValueDict = {"BookID": bookid}
+    newValueDict = {"Status": "Open", "BookFile": dest_file}
+    myDB.upsert("books", newValueDict, controlValueDict)
+
+    # update authors
+    query = 'SELECT COUNT(*) FROM books WHERE AuthorName="%s" AND (Status="Have" OR Status="Open")' % authorname
+    countbooks = myDB.action(query).fetchone()
+    havebooks = int(countbooks[0])
+    controlValueDict = {"AuthorName": authorname}
+    newValueDict = {"HaveBooks": havebooks}
+    author_query = 'SELECT * FROM authors WHERE AuthorName="%s"' % authorname
+    countauthor = myDB.action(author_query).fetchone()
+    if countauthor:
+        myDB.upsert("authors", newValueDict, controlValueDict)
+    
 def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=None, global_name=None, book_id=None):
 
     logger.debug("dest_path = %s %s" % (type(dest_path), common.to_str(dest_path)))
     logger.debug("pp_path = %s %s" % (type(pp_path), common.to_str(pp_path)))
-    # user reported a unicode exception in shutil.move but I can't reproduce it.
-    # Can't change characters by stripping accents as filename already exists with them.
-    # Maybe just need to make sure pp_path is encoded utf-8?
-    # alternatively, use shutil.copytree followed by shutil.rmtree?? 
     pp_path = pp_path.encode(lazylibrarian.SYS_ENCODING)
 
+    # check we got a book in the downloaded files
+    pp = False
+    for bookfile in os.listdir(pp_path):
+        if ((str(bookfile).split('.')[-1]) in lazylibrarian.EBOOK_TYPE):    
+            pp = True
+    if pp == False:
+        # no book found in a format we wanted. Leave for the user to delete or convert manually
+        logger.debug('Failed to locate a book in downloaded files, leaving for manual processing')
+        return pp    
+        
     try:
         if not os.path.exists(dest_path):
             logger.debug('%s does not exist, so it\'s safe to create it' % dest_path)
         else:
-            logger.debug('%s already exists. It will be overwritten' % dest_path)
-            logger.debug('Removing existing tree')
+            logger.debug('%s already exists. Removing existing tree.' % dest_path)
             shutil.rmtree(dest_path)
 
         logger.debug('Attempting to copy/move tree')
@@ -254,7 +257,7 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
                 if ((str(file3).split('.')[-1]) in lazylibrarian.EBOOK_TYPE):
                     bookID = str(file3).split("LL.(")[1].split(")")[0]
                     if bookID == book_id:
-                        logger.info('Proccessing %s' % bookID)
+                        logger.info('Processing %s' % bookID)
                         if not os.path.exists(dest_path):
                             try:
                                 os.makedirs(dest_path)
@@ -272,14 +275,14 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
 
         # try and rename the actual book file & remove non-book files
         for file2 in os.listdir(dest_path):
-            logger.debug('file extension: ' + str(file2).split('.')[-1])
+            #logger.debug('file extension: ' + str(file2).split('.')[-1])
             if ((file2.lower().find(".jpg") <= 0) & (file2.lower().find(".opf") <= 0)):
-                logger.debug('file: ' + str(file2))
                 if ((str(file2).split('.')[-1]) not in lazylibrarian.EBOOK_TYPE):
+                    logger.debug('Removing unwanted file: %s' % str(file2))
                     os.remove(os.path.join(dest_path, file2))
                 else:
+                    logger.debug('Moving %s to directory %s' % (file2, dest_path))
                     os.rename(os.path.join(dest_path, file2), os.path.join(dest_path, global_name + '.' + str(file2).split('.')[-1]))
-
         try:
             os.chmod(dest_path, 0777)
         except Exception, e:

--- a/lazylibrarian/providers.py
+++ b/lazylibrarian/providers.py
@@ -52,10 +52,10 @@ def KAT(book=None):
     except urllib2.URLError as e:
         # seems KAT returns 404 if no results, not really an error
         if not e.code == 404: 
-            logger.warn(searchURL)
-            logger.warn('Error fetching data from %s: %s' % (provider, e.reason))
+            logger.debug(searchURL)
+            logger.debug('Error fetching data from %s: %s' % (provider, e.reason))
         else:
-            logger.info(u"No results found from %s for %s" % (provider, book['searchterm']))    
+            logger.debug(u"No results found from %s for %s" % (provider, book['searchterm']))    
         data = False
 
     results = []
@@ -67,7 +67,7 @@ def KAT(book=None):
         d = feedparser.parse(data)
 
         if not len(d.entries):
-            logger.info(u"No results found from %s for %s" % (provider, book['searchterm']))
+            logger.debug(u"No results found from %s for %s" % (provider, book['searchterm']))
             pass
 
         else:
@@ -97,7 +97,7 @@ def KAT(book=None):
                 except Exception, e:
                     logger.error(u"An unknown error occurred in the KAT parser: %s" % e)
     
-    logger.info(u"Found %i results from %s for %s" % (len(results), provider, book['searchterm']))        
+    logger.debug(u"Found %i results from %s for %s" % (len(results), provider, book['searchterm']))        
     return results
 
 #
@@ -224,7 +224,7 @@ def NewzNabPlus(book=None, host=None, api_key=None, searchType=None, searchMode=
         try:
             data = ElementTree.parse(resp)
         except (urllib2.URLError, IOError, EOFError), e:
-            logger.warn('Error fetching data from %s: %s' % (host, e))
+            logger.error('Error fetching data from %s: %s' % (host, e))
             data = None
 
     except Exception, e:
@@ -243,7 +243,7 @@ def NewzNabPlus(book=None, host=None, api_key=None, searchType=None, searchMode=
                 results.append(ReturnResultsFieldsBySearchType(book, nzb, searchType, host, searchMode))
             except IndexError:
                 logger.debug('No results from %s' % host)
-        logger.info(u'Found %s nzb at %s for: %s' % (nzbcount, host, book['searchterm']))
+        logger.debug(u'Found %s nzb at %s for: %s' % (nzbcount, host, book['searchterm']))
     else:
         logger.debug('No data returned from %s' % host)
     return results

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -54,19 +54,19 @@ def search_magazines(mags=None):
         searchlist.append({"bookid": bookid, "searchterm": searchterm})
 
     if searchlist == []:
-        logger.info('There is nothing to search for.  Mark some magazines as active.')
+        logger.warn('There is nothing to search for.  Mark some magazines as active.')
 
     for book in searchlist:
 
         if lazylibrarian.USE_NZB:
             resultlist, nproviders = providers.IterateOverNewzNabSites(book, 'mag')
             if not nproviders:
-                logger.info('No nzb providers are set. Check config for NEWZNAB or TORZNAB providers')
+                logger.warn('No nzb providers are set. Check config for NEWZNAB or TORZNAB providers')
 
         if lazylibrarian.USE_TOR:
             tor_resultlist, nproviders = providers.IterateOverTorrentSites(book, 'mag')
             if not nproviders:
-                logger.info('No torrent providers are set. Check config for TORRENT providers')
+                logger.warn('No torrent providers are set. Check config for TORRENT providers')
 
             for item in tor_resultlist:  # reformat the torrent results so they look like nzbs
                 resultlist.append({

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -27,7 +27,7 @@ from lazylibrarian.searchtorrents import TORDownloadMethod
 
 def search_nzb_book(books=None, mags=None):
     if not(lazylibrarian.USE_NZB):
-        logger.debug('NZB Search is disabled')
+        logger.warn('NZB Search is disabled')
         return
     # rename this thread
     threading.currentThread().name = "SEARCHNZBBOOKS"
@@ -46,7 +46,7 @@ def search_nzb_book(books=None, mags=None):
                 shutil.rmtree(providercache)
                 os.mkdir(providercache)
             except OSError, e:
-                logger.info('Failed to clear cache: ' + str(e))
+                logger.error('Failed to clear cache: ' + str(e))
             
         #if os.path.exists(".ProviderCache"):
         #    for f in os.listdir(".ProviderCache"):
@@ -89,19 +89,19 @@ def search_nzb_book(books=None, mags=None):
         searchlist.append({"bookid": bookid, "bookName": searchbook[2], "authorName": searchbook[1], "searchterm": searchterm.strip()})
 
     if not lazylibrarian.SAB_HOST and not lazylibrarian.NZB_DOWNLOADER_BLACKHOLE and not lazylibrarian.NZBGET_HOST:
-        logger.info('No download method is set, use SABnzbd/NZBGet or blackhole')
+        logger.warn('No download method is set, use SABnzbd/NZBGet or blackhole')
 
     counter = 0
     for book in searchlist:
         resultlist, nproviders = providers.IterateOverNewzNabSites(book, 'book')
 
         if not nproviders:
-            logger.info('No providers are set. try use NEWZNAB or TORZNAB')
+            logger.warn('No providers are set. try use NEWZNAB or TORZNAB')
             return
 
         # if you can't find teh book specifically, you might find under general search
         if not resultlist:
-            logger.info("Searching for type book failed to find any books...moving to general search")
+            logger.debug("Searching for type book failed to find any books...moving to general search")
             resultlist, nproviders = providers.IterateOverNewzNabSites(book, 'general')
 
         if not resultlist:
@@ -122,7 +122,7 @@ def search_nzb_book(books=None, mags=None):
                 logger.debug("NZB Title Match %: " + str(nzbTitle_match))
 
                 if (nzbTitle_match > match_ratio):
-                    logger.info(u'Found NZB: %s' % nzb['nzbtitle'])
+                    logger.debug(u'Found NZB: %s' % nzb['nzbtitle'])
                     addedCounter = addedCounter + 1
                     bookid = book['bookid']
                     nzbTitle = (book["authorName"] + ' - ' + book['bookName'] + ' LL.(' + book['bookid'] + ')').strip()
@@ -157,7 +157,7 @@ def search_nzb_book(books=None, mags=None):
                         notifiers.notify_snatch(formatter.latinToAscii(nzbTitle) + ' at ' + formatter.now())
                     break
             if addedCounter == 0:
-                logger.info("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() + ". Adding book to queue.")
+                logger.debug("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() + ". Adding book to queue.")
         counter = counter + 1
 
     logger.info("NZBSearch for Wanted items complete")
@@ -200,18 +200,18 @@ def NZBDownloadMethod(bookid=None, nzbprov=None, nzbtitle=None, nzburl=None):
                 f = open(nzbpath, 'w')
                 f.write(nzbfile)
                 f.close()
-                logger.info('NZB file saved to: ' + nzbpath)
+                logger.debug('NZB file saved to: ' + nzbpath)
                 download = True
                 try:
                     os.chmod(nzbpath, 0777)
                 except Exception, e:
-                    logger.info("Could not chmod path: " + str(nzbpath))
+                    logger.error("Could not chmod path: " + str(nzbpath))
             except Exception, e:
                 logger.error('%s not writable, NZB not saved. Error: %s' % (nzbpath, e))
                 download = False
 
     else:
-        logger.error('No NZB download method is enabled, check config.')
+        logger.warn('No NZB download method is enabled, check config.')
         return False
 
     if download:

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -227,7 +227,9 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
                                      lazylibrarian.DELUGE_USER,
                                      lazylibrarian.DELUGE_PASS)
             client.connect()
-            download = client.call('add_torrent_url', tor_url, {"name": tor_title})
+            if '?' in tor_url:
+                tor_url = tor_url.split('?')[0]
+            download = client.call('core.add_torrent_url', tor_url, {"name": tor_title})
             logger.debug('Deluge return value: %s' % download)
 
     else:

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -31,7 +31,7 @@ import gzip
 
 def search_tor_book(books=None, mags=None):
     if not(lazylibrarian.USE_TOR):
-        logger.debug('Torrent search is disabled')
+        logger.warn('Torrent search is disabled')
         return
     # rename this thread
     threading.currentThread().name = "SEARCHTORBOOKS"
@@ -93,12 +93,12 @@ def search_tor_book(books=None, mags=None):
         # print book.keys()
         resultlist, nproviders = providers.IterateOverTorrentSites(book, 'book')
         if not nproviders:
-            logger.info('No torrent providers are set, check config for TORRENT providers')
+            logger.warn('No torrent providers are set, check config for TORRENT providers')
             return
 
         # if you can't find teh book specifically, you might find under general search
         if not resultlist:
-            logger.info("Searching for type book failed to find any books...moving to general search")
+            logger.debug("Searching for type book failed to find any books...moving to general search")
             resultlist, nproviders = providers.IterateOverTorrentSites(book, 'general')
 
         if not resultlist:
@@ -119,7 +119,7 @@ def search_tor_book(books=None, mags=None):
                 logger.debug("Torrent Title Match %: " + str(tor_Title_match))
 
                 if (tor_Title_match > match_ratio):
-                    logger.info(u'Found Torrent: %s' % tor['tor_title'])
+                    logger.debug(u'Found Torrent: %s' % tor['tor_title'])
                     addedCounter = addedCounter + 1
                     bookid = book['bookid']
                     tor_Title = (book["authorName"] + ' - ' + book['bookName'] + ' LL.(' + book['bookid'] + ')').strip()
@@ -148,7 +148,7 @@ def search_tor_book(books=None, mags=None):
                         notifiers.notify_snatch(formatter.latinToAscii(tor_Title) + ' at ' + formatter.now())
                     break
             if addedCounter == 0:
-                logger.info("No torrent's found for " + (book["authorName"] + ' ' + book['bookName']).strip() + ". Adding book to queue.")
+                logger.debug("No torrent's found for " + (book["authorName"] + ' ' + book['bookName']).strip() + ". Adding book to queue.")
         counter = counter + 1
     logger.info("TORSearch for Wanted items complete")
 
@@ -216,7 +216,7 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
             torrent_file = open(tor_path, 'wb')
             torrent_file.write(torrent)
             torrent_file.close()
-            logger.info('Torrent file saved: %s' % tor_title)
+            logger.debug('Torrent file saved: %s' % tor_title)
             download = True
 
         if (lazylibrarian.TOR_DOWNLOADER_UTORRENT):
@@ -238,9 +238,9 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
                 download = client.call('core.add_torrent_url', tor_url, {"name": tor_title})
                 logger.debug('Deluge return value: %s' % download)
             else:
-                logger.error('Need user & pass for deluge, check config.')
+                logger.warn('Need user & pass for deluge, check config.')
     else:
-        logger.error('No torrent download method is enabled, check config.')
+        logger.warn('No torrent download method is enabled, check config.')
         return False
 
     if download:

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -156,6 +156,7 @@ def search_tor_book(books=None, mags=None):
 def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
     myDB = database.DBConnection()
     download = False
+    full_url = tor_url # keep the url as stored in "wanted" table
     if (lazylibrarian.USE_TOR) and (lazylibrarian.TOR_DOWNLOADER_DELUGE or lazylibrarian.TOR_DOWNLOADER_UTORRENT
                                     or lazylibrarian.TOR_DOWNLOADER_BLACKHOLE or lazylibrarian.TOR_DOWNLOADER_TRANSMISSION):
 
@@ -196,7 +197,13 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
             except urllib2.URLError as e:
                 logger.warn('Error fetching torrent from url: ' + tor_url + ' %s' % e.reason)
                 return
-
+                
+        # strip url back to the .torrent for passing to downloaders
+        # deluge needs it stripping, transmission doesn't mind
+        # not sure about utorrent
+        if '?' in tor_url: 
+            tor_url = tor_url.split('?')[0]
+            
         if (lazylibrarian.TOR_DOWNLOADER_BLACKHOLE):
             logger.debug('Torrent blackhole')
             tor_title = common.removeDisallowedFilenameChars(tor_title)
@@ -226,12 +233,12 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
                                      int(lazylibrarian.DELUGE_PORT),
                                      lazylibrarian.DELUGE_USER,
                                      lazylibrarian.DELUGE_PASS)
-            client.connect()
-            if '?' in tor_url:
-                tor_url = tor_url.split('?')[0]
-            download = client.call('core.add_torrent_url', tor_url, {"name": tor_title})
-            logger.debug('Deluge return value: %s' % download)
-
+            if lazylibrarian.DELUGE_USER and lazylibrarian.DELUGE_PASS:
+                client.connect()
+                download = client.call('core.add_torrent_url', tor_url, {"name": tor_title})
+                logger.debug('Deluge return value: %s' % download)
+            else:
+                logger.error('Need user & pass for deluge, check config.')
     else:
         logger.error('No torrent download method is enabled, check config.')
         return False
@@ -239,10 +246,10 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
     if download:
         logger.debug(u'Torrent file has been downloaded from %s' % tor_url)
         myDB.action('UPDATE books SET status = "Snatched" WHERE BookID="%s"' % bookid)
-        myDB.action('UPDATE wanted SET status = "Snatched" WHERE NZBurl="%s"' % tor_url)
+        myDB.action('UPDATE wanted SET status = "Snatched" WHERE NZBurl="%s"' % full_url)
     else:
-        logger.error(u'Failed to download torrent @ <a href="%s">%s</a>' % (tor_url, tor_url))
-        myDB.action('UPDATE wanted SET status = "Failed" WHERE NZBurl="%s"' % tor_url)
+        logger.error(u'Failed to download torrent @ <a href="%s">%s</a>' % (full_url, tor_url))
+        myDB.action('UPDATE wanted SET status = "Failed" WHERE NZBurl="%s"' % full_url)
 
 
 def CalcTorrentHash(torrent):

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -522,6 +522,14 @@ class WebInterface(object):
         raise cherrypy.HTTPRedirect("authorPage?AuthorName=%s" % AuthorName)
     refreshAuthor.exposed = True
 
+    def importAlternate(self):
+        try:
+            threading.Thread(target=postprocess.processAlternate(lazylibrarian.ALTERNATE_DIR)).start()
+        except Exception, e:
+            logger.error(u'Unable to complete the import: %s' % e)
+        raise cherrypy.HTTPRedirect("home")
+    importAlternate.exposed = True
+
     def libraryScan(self):
         try:
             threading.Thread(target=librarysync.LibraryScan(lazylibrarian.DESTINATION_DIR)).start()

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -102,6 +102,7 @@ class WebInterface(object):
             "nzbget_priority":  lazylibrarian.NZBGET_PRIORITY,
             "destination_copy": checked(lazylibrarian.DESTINATION_COPY),
             "destination_dir":  lazylibrarian.DESTINATION_DIR,
+            "alternate_dir":    lazylibrarian.ALTERNATE_DIR,
             "download_dir":     lazylibrarian.DOWNLOAD_DIR,
             "sab_cat":          lazylibrarian.SAB_CAT,
             "usenet_retention": lazylibrarian.USENET_RETENTION,
@@ -219,7 +220,7 @@ class WebInterface(object):
                      nzb_downloader_sabnzbd=0, nzb_downloader_nzbget=0, nzb_downloader_blackhole=0, use_nzb=0, use_tor=0,
                      proxy_host=None, proxy_type=None, sab_host=None, sab_port=None, sab_subdir=None, sab_api=None, sab_user=None, sab_pass=None,
                      destination_copy=0, destination_dir=None, download_dir=None, sab_cat=None, usenet_retention=None, nzb_blackholedir=None,
-                     torrent_dir=None, numberofseeders=0, tor_downloader_blackhole=0, tor_downloader_utorrent=0,
+                     alternate_dir=None, torrent_dir=None, numberofseeders=0, tor_downloader_blackhole=0, tor_downloader_utorrent=0,
                      nzbget_host=None, nzbget_user=None, nzbget_pass=None, nzbget_cat=None, nzbget_priority=0, newznab0=0, newznab_host0=None, newznab_api0=None,
                      newznab1=0, newznab_host1=None, newznab_api1=None, newznab2=0, newznab_host2=None, newznab_api2=None, newznab3=0, newznab_host3=None, newznab_api3=None,
                      newznab4=0, newznab_host4=None, newznab_api4=None, newzbin=0, newzbin_uid=None, newzbin_pass=None, kat=0, kat_host=None, ebook_type=None, book_api=None,
@@ -271,6 +272,7 @@ class WebInterface(object):
 
         lazylibrarian.DESTINATION_COPY = int(destination_copy)
         lazylibrarian.DESTINATION_DIR = destination_dir
+        lazylibrarian.ALTERNATE_DIR = alternate_dir
         lazylibrarian.DOWNLOAD_DIR = download_dir
         lazylibrarian.USENET_RETENTION = usenet_retention
         lazylibrarian.NZB_BLACKHOLEDIR = nzb_blackholedir

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -912,8 +912,8 @@ class WebInterface(object):
     def history(self, source=None):
         myDB = database.DBConnection()
         if not source:
-            # wanted status holds snatched processed for all, plus skipped for magazines
-            history = myDB.select("SELECT * from wanted WHERE Status != 'Skipped'")
+            # wanted status holds snatched processed for all, plus skipped and ignored for magazine back issues
+            history = myDB.select("SELECT * from wanted WHERE Status != 'Skipped' and Status != 'Ignored'")
             return serve_template(templatename="history.html", title="History", history=history)
         elif source == "magazines":
             books = myDB.select("SELECT * from wanted WHERE Status = 'Skipped'")  # or Status = 'Snatched'")

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -902,6 +902,8 @@ class WebInterface(object):
 
     def manage(self, AuthorName=None, action=None, whichStatus=None, source=None, **args):
         myDB = database.DBConnection()
+        # books only holds status of skipped wanted open have ignored
+        # wanted holds status of snatched processed
         books = myDB.select('SELECT * FROM books WHERE Status = ?', [whichStatus])
         return serve_template(templatename="managebooks.html", title="Book Status Management", books=books, whichStatus=whichStatus)
     manage.exposed = True
@@ -909,6 +911,7 @@ class WebInterface(object):
     def history(self, source=None):
         myDB = database.DBConnection()
         if not source:
+            # wanted status holds snatched processed for all, plus skipped for magazines
             history = myDB.select("SELECT * from wanted WHERE Status != 'Skipped'")
             return serve_template(templatename="history.html", title="History", history=history)
         elif source == "magazines":


### PR DESCRIPTION
Added library scan for magazines to import existing or manually downloaded issues
New table to hold magazine issues and dates
If multiple issues of a magazine are in your library, show a page listing the issues
If only one issue, open it as before
Changes to log messages in postprocessing, keep more debug log files
If postprocessing fails, ie book in wrong format, do not delete, leave in download
directory and tell user it's there. User can delete or convert to correct format manually
Refactored postprocess to reduce duplicated code
Moved lots of info messages to debug to reduce log noise
Allow multiple issues of a magazine to be downloaded in one scan
Various date fixes and date handling improvements for magazine downloads
Added pushover device support, and test button for pushover notifications to return device list
Added python !# to LazyLibrarian.py in case user tries to run it from a shell
Deluge fix for core.add_torrent_url, added warning if no deluge user/pass
Magazines skipped issues can be marked ignored/have to hide them in list
Consolidated booktype extension checking into a function
Added alternate import folder for manual book adding. Place a book into the folder, hit the button,
and the book is processed as if LL downloaded it. Author and book need to be listed in the database already, or a warning is generated. ie the alternate import will not add an author to db, or add a book entry.
Look for metadata in any .opf file in current directory now, not just calibre-named "metadata.opf"
in case there is a LL style "book - author.opf"
