### PR TITLE
Reworked metadata logic

### DIFF
--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -407,7 +407,7 @@ class WebInterface(object):
 
         lazylibrarian.config_write()
 
-        logger.debug('Config file has been updated')
+        logger.info('Config file has been updated')
         raise cherrypy.HTTPRedirect("config")
 
     configUpdate.exposed = True


### PR DESCRIPTION
Read metadata from book first, if there is any embedded.
Allow metadata to be overridden by opf file, if there is one.
If neither give us author and book, try to extract from the filename.
This allows user to fairly easily merge authors where the embedded data differs,
eg books by "James Lovelock" and "James E. Lovelock" can be merged into one author
by editing the metadata opf files so the author names match.
If the book or opf file contain both isbn and language, cache them for later use.
Otherwise look the language up during the scan.