### PR TITLE
Post processing changes, bug fixes, extra locale messages

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -44,6 +44,8 @@
                   <br>
                   <br>
                   <label>Logdir:</label><input type="text" name="logdir" value="${lazylibrarian.LOGDIR}" size="50"><br>
+                  <label>Log Level:</label><input type="text" name="loglevel" value="${lazylibrarian.LOGLEVEL}" size="20"><br>
+                  <i class="smalltext">0=Quiet, 1=Normal, 2=Debug, >2 file/console log always set to debug (ignores toggle)</i>
 		  <br>
 		  <br>
 		  <div>

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -9,6 +9,7 @@
 			<li><a href="clearhistory?type=all" id="button">Clear All History</a></li>
 			<li><a href="clearhistory?type=Processed" id="button">Clear Processed</a></li>
 			<li><a href="clearhistory?type=Snatched" id="button">Clear Snatched</a></li>
+			<li><a href="clearhistory?type=Failed" id="button">Clear Failed</a></li>
 			</ul>
 	</div>	
 </%def>

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -13,7 +13,7 @@
 
     <form action="pastIssues" method="get">
     Manage Issues with status <select name="whichStatus">
-        %for item in ['Skipped', 'Wanted', 'Snatched', 'Ignored']:
+        %for item in ['Skipped', 'Wanted', 'Snatched', Processed', 'Ignored']:
             <option value="${item}"
                 %if whichStatus == item:
                     selected = "selected"
@@ -55,7 +55,7 @@
     <p>
 
     Change selected magazines to <select class="markIssues" name="action" style="margin-left:30px;margin-top:15px;margin-bottom:15px;">
-        %for item in ['Skipped', 'Wanted', 'Have', 'Ignored']:
+        %for item in ['Skipped', 'Wanted', 'Ignored', 'Delete']:
             %if whichStatus != item:
                 <option value="${item}">${item}</option>
             %endif

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -13,7 +13,7 @@
 
     <form action="pastIssues" method="get">
     Manage Issues with status <select name="whichStatus">
-        %for item in ['Skipped', 'Wanted', 'Snatched', Processed', 'Ignored']:
+        %for item in ['Skipped', 'Wanted', 'Snatched', 'Processed', 'Ignored']:
             <option value="${item}"
                 %if whichStatus == item:
                     selected = "selected"

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -13,7 +13,7 @@ import datetime
 import locale
 import calendar
 import time
-
+import subprocess
 import ConfigParser
 from lib.apscheduler.scheduler import Scheduler
 
@@ -672,6 +672,23 @@ def build_monthtable():
         except:
             locale.setlocale(locale.LC_ALL, current_locale)  # restore entry state
             logger.warn("Unable to load requested locale [%s]" % lang)
+            try:
+                if '_' in lang:
+                    wanted_lang = lang.split('_')[0]
+                else:
+                    wanted_lang = lang
+                params = ['locale', '-a']
+                all_locales = subprocess.check_output(params).split()
+                locale_list = []
+                for a_locale in all_locales:
+                    if a_locale.startswith(wanted_lang):
+                        locale_list.append(a_locale)
+                if locale_list:
+                    logger.warn("Found these alternatives: " + str(locale_list))
+                else:
+                    logger.warn("Unable to find an alternative")
+            except:
+                logger.warn("Unable to get a list of alternatives")
             logger.info("Set locale back to entry state %s" % current_locale)
     # quick sanity check, warn if no english names in table
     eng = 0

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -187,9 +187,9 @@ SEARCH_INTERVAL = 720  # Every 12 hours
 SCAN_INTERVAL = 10  # Every 10 minutes
 FULL_SCAN = 0  # full scan would remove books from db
 ADD_AUTHOR = 1  # auto add authors not found in db from goodreads
-# value to mark missing books (deleted/removed) in db, can be 'Open', 'Ignored',' 'Wanted','Skipped'
+# value to mark missing books (deleted/removed) in db, can be 'Open', 'Ignored', 'Wanted','Skipped'
 NOTFOUND_STATUS = 'Skipped'
-# value to mark new books (when importing a new author), can be 'Open', 'Ignored',' 'Wanted','Skipped'
+# value to mark new books (when importing a new author), can be 'Open', 'Ignored', 'Wanted','Skipped'
 NEWBOOK_STATUS = 'Skipped'
 EBOOK_DEST_FOLDER = None
 EBOOK_DEST_FILE = None
@@ -270,7 +270,7 @@ def check_section(sec):
         return False
 
 
-def check_setting_bool(config, cfg_name, item_name, def_val):
+def check_setting_bool(config, cfg_name, item_name, def_val, log=True):
     """ Check if option exists and coerce to boolean, if not create it """
     try:
         my_val = config.getboolean(cfg_name, item_name)
@@ -278,24 +278,29 @@ def check_setting_bool(config, cfg_name, item_name, def_val):
         my_val = def_val
         check_section(cfg_name)
         config.set(cfg_name, item_name, my_val)
-    logger.debug(item_name + " -> " + str(my_val))
+    if log:
+        logger.debug(item_name + " -> " + str(my_val))
     return my_val
 
 
-def check_setting_int(config, cfg_name, item_name, def_val):
+def check_setting_int(config, cfg_name, item_name, def_val, log=True):
+    """ Check if option exists and coerce to int, if not create it """
     try:
         my_val = config.getint(cfg_name, item_name)
     except:
         my_val = def_val
         check_section(cfg_name)
         config.set(cfg_name, item_name, my_val)
-    logger.debug(item_name + " -> " + str(my_val))
+    if log:
+        logger.debug(item_name + " -> " + str(my_val))
     return my_val
 
 
 def check_setting_str(config, cfg_name, item_name, def_val, log=True):
+    """ Check if option exists and coerce to string, if not create it """
     try:
         my_val = config.get(cfg_name, item_name)
+        # Old config file format had strings in quotes. ConfigParser doesn't.
         if my_val.startswith('"'):
             my_val = my_val[1:]
         if my_val.endswith('"'):
@@ -306,9 +311,6 @@ def check_setting_str(config, cfg_name, item_name, def_val, log=True):
         config.set(cfg_name, item_name, my_val)
     if log:
         logger.debug(item_name + " -> " + my_val)
-    else:
-        logger.debug(item_name + " -> ******")
-
     return my_val
 
 
@@ -391,10 +393,10 @@ def initialize():
             LOGLEVEL, LOGDIR, CFGLOGLEVEL))
         if LOGLEVEL > 2:
             LOGFULL = True
-            logger.info("Screen Log is DEBUG")
+            logger.info("Screen Log set to DEBUG")
         else:
             LOGFULL = False
-            logger.info("Screen Log is INFO/WARN/ERROR")
+            logger.info("Screen Log set to INFO/WARN/ERROR")
 
         # keep track of last api calls so we don't call more than once per second
         # to respect api terms, but don't wait un-necessarily either

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -13,7 +13,7 @@ except ImportError:
         import PythonMagick
         have_magick = "pythonmagick"
     except ImportError:
-        have_magick = False
+        have_magick = "convert"  # may have external, don't know yet
 
 
 def create_cover(issuefile=None):
@@ -30,15 +30,18 @@ def create_cover(issuefile=None):
                     img = PythonMagick.Image()
                     img.read(issuefile + '[0]')
                     img.write(coverfile)
-                else:
+                elif have_magick == 'convert': 
                     # No PythonMagick in python3, hence allow wand, but more complicated
-                    # to install - maybe use external imagemagick convert?
+                    # to install - try to use external imagemagick convert?
                     # should work on win/mac/linux as long as imagemagick is installed
                     # but how best to check if external imagemagick is installed?
-                    # maybe set a global to True, and set to False if subprocess fails
                     # Maybe replace program name 'convert' by a global that user can edit
-                    params = ['convert', issuefile + '[0]', coverfile]
-                    subprocess.check_call(params)
+                    try:
+                        params = ['convert', issuefile + '[0]', coverfile]
+                        subprocess.check_call(params)
+                    except:
+                        logger.warn('No ImageMagick "convert" found')
+                        have_magick = ''  # don't keep trying
             except:
                 logger.debug("Unable to create cover for %s" % issuefile)
 

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -60,6 +60,18 @@ def processAlternate(source_dir=None):
         logger.warn("No book file found in %s" % source_dir)
 
 
+def schedule_processor(action='Start'):
+    """ Start or stop the postprocessor cron job """
+    if action == 'Start':        
+        for job in lazylibrarian.SCHED.get_jobs():
+            if "processDir" in str(job):
+                return  # return if already running, if not, start a new one
+        lazylibrarian.SCHED.add_interval_job(postprocess.processDir, minutes=int(lazylibrarian.SCAN_INTERVAL))
+    else:
+        for job in lazylibrarian.SCHED.get_jobs():
+            if "processDir" in str(job):
+                lazylibrarian.SCHED.unschedule_job(job)
+
 def processDir(force=False):
     # rename this thread
     threading.currentThread().name = "POSTPROCESS"
@@ -80,7 +92,8 @@ def processDir(force=False):
     snatched = myDB.select('SELECT * from wanted WHERE Status="Snatched"')
 
     if force == False and len(snatched) == 0:
-        logger.debug('Nothing marked as snatched. Nothing to process.')
+        logger.debug('Nothing marked as snatched. Stopping cron job.')
+        schedule_processor(action='Stop')
     elif len(downloads) == 0:
         logger.debug('No downloads are found. Nothing to process.')
     else:
@@ -178,12 +191,7 @@ def processDir(force=False):
             else:
                 logger.error('Postprocessing for %s has failed.' % global_name)
                 logger.error('Warning - Residual files remain in %s' % pp_path)
-        #
-        # TODO Seems to be duplication here. Can we just scan once for snatched books
-        # instead of scan for snatched and then scan for directories with "LL.(bookID)" in?
-        # Should there be any directories with "LL.(bookID)" that aren't in snatched?
-        # Maybe this was put in for manually downloaded books?
-        #
+
         downloads = os.listdir(processpath)  # check in case we processed/deleted some above
         for directory in downloads:
             if "LL.(" in directory:

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -60,7 +60,7 @@ def processAlternate(source_dir=None):
         logger.warn("No book file found in %s" % source_dir)
 
 
-def processDir():
+def processDir(force=False):
     # rename this thread
     threading.currentThread().name = "POSTPROCESS"
 
@@ -79,10 +79,10 @@ def processDir():
     myDB = database.DBConnection()
     snatched = myDB.select('SELECT * from wanted WHERE Status="Snatched"')
 
-    if snatched is None:
-        logger.info('No books are snatched. Nothing to process.')
-    elif downloads is None:
-        logger.info('No downloads are found. Nothing to process.')
+    if force == False and len(snatched) == 0:
+        logger.debug('Nothing marked as snatched. Nothing to process.')
+    elif len(downloads) == 0:
+        logger.debug('No downloads are found. Nothing to process.')
     else:
         ppcount = 0
         for book in snatched:

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -17,7 +17,6 @@ def search_magazines(mags=None):
 
     myDB = database.DBConnection()
     searchlist = []
-    resultlist = []
     threading.currentThread().name = "SEARCHMAGS"
 
     if mags is None:  # backlog search
@@ -54,6 +53,8 @@ def search_magazines(mags=None):
 
     for book in searchlist:
 
+        resultlist = []
+        tor_resultlist = []
         if lazylibrarian.USE_NZB:
             resultlist, nproviders = providers.IterateOverNewzNabSites(book, 'mag')
             if not nproviders:

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -5,7 +5,7 @@ import re
 
 import lazylibrarian
 
-from lazylibrarian import logger, database, formatter, providers, notifiers, common
+from lazylibrarian import logger, database, formatter, providers, notifiers, common, postprocess
 
 from lib.fuzzywuzzy import fuzz
 from lazylibrarian.searchtorrents import TORDownloadMethod
@@ -288,5 +288,6 @@ def search_magazines(mags=None):
                 else:
                     NZBDownloadMethod(items['bookid'], items['nzbprov'], items['nzbtitle'], items['nzburl'])
                 notifiers.notify_snatch(formatter.latinToAscii(items['nzbtitle']) + ' at ' + formatter.now())
+                postprocess.schedule_processor(action='Start')
             maglist = []
     logger.info("Search for magazines complete")

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -7,7 +7,7 @@ import re
 import lazylibrarian
 import request
 
-from lazylibrarian import logger, database, formatter, providers, nzbget, sabnzbd, notifiers, classes
+from lazylibrarian import logger, database, formatter, providers, nzbget, sabnzbd, notifiers, classes, postprocess
 
 from lib.fuzzywuzzy import fuzz
 
@@ -137,6 +137,7 @@ def search_nzb_book(books=None, mags=None):
                         else:
                             NZBDownloadMethod(bookid, nzbprov, nzbTitle, nzburl)
                         notifiers.notify_snatch(formatter.latinToAscii(nzbTitle) + ' at ' + formatter.now())
+                        postprocess.schedule_processor(action='Start')
                     break
             if addedCounter == 0:
                 logger.debug("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() +

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -134,6 +134,7 @@ def search_tor_book(books=None, mags=None):
                     if not snatchedbooks:
                         TORDownloadMethod(bookid, tor_prov, tor_Title, tor_url)
                         notifiers.notify_snatch(formatter.latinToAscii(tor_Title) + ' at ' + formatter.now())
+                        postprocess.schedule_processor(action='Start')
                     break
             if addedCounter == 0:
                 logger.debug("No torrent's found for " + (book["authorName"] + ' ' +

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -165,17 +165,21 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
                 value = value.replace(' ', '%20')  # and encode any spaces
                 tor_url = url + '&file=' + value
 
+            # strip url back to the .torrent as some sites add parameters
+            if '?' in tor_url:
+                tor_url = tor_url.split('?')[0]
+
             request = urllib2.Request(ur'%s' % tor_url)
             if lazylibrarian.PROXY_HOST:
                 request.set_proxy(lazylibrarian.PROXY_HOST, lazylibrarian.PROXY_TYPE)
             request.add_header('Accept-encoding', 'gzip')
             request.add_header('User-Agent', common.USER_AGENT)
 
-            if tor_prov == 'KAT':
-                host = lazylibrarian.KAT_HOST
-                if not str(host)[:4] == "http":
-                    host = 'http://' + host
-                request.add_header('Referer', host)
+            #if tor_prov == 'KAT':
+            #    host = lazylibrarian.KAT_HOST
+            #    if not str(host)[:4] == "http":
+            #        host = 'http://' + host
+            #    request.add_header('Referer', host)
 
             try:
                 response = urllib2.urlopen(request, timeout=90)
@@ -189,12 +193,6 @@ def TORDownloadMethod(bookid=None, tor_prov=None, tor_title=None, tor_url=None):
             except urllib2.URLError as e:
                 logger.warn('Error fetching torrent from url: ' + tor_url + ' %s' % e.reason)
                 return
-
-        # strip url back to the .torrent for passing to downloaders
-        # deluge needs it stripping, transmission doesn't mind
-        # not sure about utorrent
-        if '?' in tor_url:
-            tor_url = tor_url.split('?')[0]
 
         if (lazylibrarian.TOR_DOWNLOADER_BLACKHOLE):
             logger.debug('Torrent blackhole')

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -683,19 +683,23 @@ class WebInterface(object):
                 myDB.upsert("wanted", newValueDict, controlValueDict)
                 title = myDB.select("SELECT * from wanted WHERE NZBurl = ?", [nzburl])
                 for item in title:
-                    bookid = item['BookID']
-                    nzbprov = item['NZBprov']
-                    nzbtitle = item['NZBtitle']
                     nzburl = item['NZBurl']
-                    nzbmode = item['NZBmode']
-                    maglist.append({
-                        'bookid': bookid,
-                        'nzbprov': nzbprov,
-                        'nzbtitle': nzbtitle,
-                        'nzburl': nzburl,
-                        'nzbmode': nzbmode
-                    })
-                logger.info(u'Status set to %s for %s' % (action, nzbtitle))
+                    if action == 'Delete':
+                        myDB.action('DELETE from wanted WHERE NZBurl="%s"' % nzburl)
+                        logger.debug(u'Item %s removed from past issues' % nzburl)
+                    else:
+                        bookid = item['BookID']
+                        nzbprov = item['NZBprov']
+                        nzbtitle = item['NZBtitle']
+                        nzbmode = item['NZBmode']
+                        maglist.append({
+                            'bookid': bookid,
+                            'nzbprov': nzbprov,
+                            'nzbtitle': nzbtitle,
+                            'nzburl': nzburl,
+                            'nzbmode': nzbmode
+                        })
+                        logger.info(u'Status set to %s for %s' % (action, nzbtitle))
 
         # start searchthreads
         if action == 'Wanted':
@@ -987,7 +991,7 @@ class WebInterface(object):
         myDB = database.DBConnection()
         if type == 'all':
             logger.info(u"Clearing all history")
-            myDB.action('DELETE from wanted')
+            myDB.action("DELETE from wanted WHERE Status != 'Skipped' and Status != 'Ignored'")
         else:
             logger.info(u"Clearing history where status is %s" % type)
             myDB.action('DELETE from wanted WHERE Status="%s"' % type)

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -686,7 +686,8 @@ class WebInterface(object):
                     nzburl = item['NZBurl']
                     if action == 'Delete':
                         myDB.action('DELETE from wanted WHERE NZBurl="%s"' % nzburl)
-                        logger.debug(u'Item %s removed from past issues' % nzburl)
+                        logger.debug(u'Item %s deleted from past issues' % nzburl)
+                        maglist.append({'nzburl': nzburl})
                     else:
                         bookid = item['BookID']
                         nzbprov = item['NZBprov']
@@ -699,8 +700,11 @@ class WebInterface(object):
                             'nzburl': nzburl,
                             'nzbmode': nzbmode
                         })
-                        logger.info(u'Status set to %s for %s' % (action, nzbtitle))
 
+        if action == 'Delete':
+            logger.info(u'Deleted %s items from past issues' % (len(maglist)))
+        else:            
+            logger.info(u'Status set to %s for %s past issues' % (action, len(maglist)))
         # start searchthreads
         if action == 'Wanted':
             for items in maglist:

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -1075,7 +1075,7 @@ class WebInterface(object):
 # ALL ELSE ##########################################################
 
     def forceProcess(self, source=None):
-        threading.Thread(target=postprocess.processDir).start()
+        threading.Thread(target=postprocess.processDir(force=True)).start()
         raise cherrypy.HTTPRedirect(source)
     forceProcess.exposed = True
 

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -717,6 +717,7 @@ class WebInterface(object):
                 else:
                     snatch = NZBDownloadMethod(items['bookid'], items['nzbprov'], items['nzbtitle'], items['nzburl'])
                 notifiers.notify_snatch(items['nzbtitle'] + ' at ' + formatter.now())
+                postprocess.schedule_processor(action='Start')
         raise cherrypy.HTTPRedirect("pastIssues")
     markIssues.exposed = True
 
@@ -881,17 +882,19 @@ class WebInterface(object):
     def showJobs(self):
         # show the current status of LL cron jobs in the log
         for job in lazylibrarian.SCHED.get_jobs():
-            jobname = str(job).split(' ')[0].split('.')[2]
-            if jobname == "search_magazines":
+            if "search_magazines" in str(job):
                 jobname = "[CRON] - Check for new magazine issues"
-            elif jobname == "checkForUpdates":
+            elif "checkForUpdates" in str(job):
                 jobname = "[CRON] - Check for LazyLibrarian update"
-            elif jobname == "search_tor_book":
+            elif "search_tor_book" in str(job):
                 jobname = "[CRON] - TOR book search"
-            elif jobname == "search_nzb_book":
+            elif "search_nzb_book" in str(job):
                 jobname = "[CRON] - NZB book search"
-            elif jobname == "processDir":
+            elif "processDir" in str(job):
                 jobname = "[CRON] - Process download directory"
+            else:       
+                jobname = str(job).split(' ')[0].split('.')[2]
+
             jobtime = str(job).split('[')[1].split('.')[0]
             logger.info(u"%s [%s" % (jobname, jobtime))
         logger.info(u"XMLCache %s hits, %s miss" % (int(lazylibrarian.CACHE_HIT), int(lazylibrarian.CACHE_MISS)))

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -65,7 +65,7 @@ class WebInterface(object):
     config.exposed = True
 
     def configUpdate(self, http_host='0.0.0.0', http_root=None, http_user=None, http_port=5299,
-                     http_pass=None, http_look=None, launch_browser=0, logdir=None,
+                     http_pass=None, http_look=None, launch_browser=0, logdir=None, loglevel=2,
                      imp_onlyisbn=0, imp_singlebook=0, imp_preflang=None, imp_monthlang=None,
                      imp_autoadd=None, match_ratio=80, nzb_downloader_sabnzbd=0, nzb_downloader_nzbget=0,
                      nzb_downloader_blackhole=0, use_nzb=0, use_tor=0, proxy_host=None, proxy_type=None,
@@ -108,6 +108,7 @@ class WebInterface(object):
         lazylibrarian.PROXY_HOST = proxy_host
         lazylibrarian.PROXY_TYPE = proxy_type
         lazylibrarian.LOGDIR = logdir
+        lazylibrarian.LOGLEVEL = formatter.check_int(loglevel, 2)
         lazylibrarian.MATCH_RATIO = formatter.check_int(match_ratio, 80)
 
         lazylibrarian.IMP_ONLYISBN = bool(imp_onlyisbn)


### PR DESCRIPTION
Clear all history only deletes books now, ignores magazine past-issues.
These can be deleted (or marked skipped/ignored) from the magazines past-issues 
page. Delete snatched/processed deletes both books and magazines with matching status
Added loglevel to config screen
Added messages to help if requested locales are not found
Cron post-process job only runs if there are items marked as snatched.
No point in running every 10 minutes if there's nothing we're waiting for.
Force post-process runs even if nothing marked snatched, in case we downloaded items manually.
Fix for KAT sending html response instead of torrent file