### PR TITLE
Issue buttons, separate extensions for books/mags, date matching improvements

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -143,6 +143,11 @@
                     <br>
                     <i class="smalltext">Comma separated file extensions:
                     <BR>Default: epub, mobi, pdf </i>
+                    <BR>
+                    <label>Magazine Format:</label><input type="text" name="mag_type" value="${lazylibrarian.MAG_TYPE}" size="0" maxlength="40">
+                    <br>
+                    <i class="smalltext">Comma separated file extensions:
+                    <BR>Default: pdf </i>
                 </td>
             </tr>
         </table>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -646,7 +646,9 @@
                     <BR>
                     <label>Convert program:</label><input type="text" placeholder="convert program" name="imp_convert" value="${lazylibrarian.IMP_CONVERT}" size="50" maxlength="90">
                     <BR><BR>
-                    <small>Program for creating magazine covers (example: ImageMagick "convert")</small>
+                    <small>Program for creating magazine covers (example: ImageMagick "convert")
+                    <BR>Leave blank to use PythonMagick or Wand interfaces to ImageMagick
+                    <BR>Enter  None  to disable cover creation</small>
                 </td>
             </tr>
             <tr>
@@ -699,7 +701,8 @@
                     %>
                   <label>One book per directory:</label><input type="checkbox" name="imp_singlebook" value=1 ${checked} />
                   <br>
-                  <i class="smalltext">This imports one book per directory, tick this if you keep multiple formats of the same book in the same directory</i>
+                  <i class="smalltext">This imports one book per directory
+                  <BR>Tick if you keep multiple formats of the same book in the same directory</i>
                   </div>
                 </td>
                 <td> 

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -639,7 +639,7 @@
                     <BR><BR>
                     <small>Directory for a copy to be placed for auto add process</small>
                     <BR>
-                    <label>Convert program:</label><input type="text" placeholder="convert" name="imp_convert" value="${lazylibrarian.IMP_CONVERT}" size="50" maxlength="90">
+                    <label>Convert program:</label><input type="text" placeholder="convert program" name="imp_convert" value="${lazylibrarian.IMP_CONVERT}" size="50" maxlength="90">
                     <BR><BR>
                     <small>Program for creating magazine covers (example: ImageMagick "convert")</small>
                 </td>

--- a/data/interfaces/default/issues.html
+++ b/data/interfaces/default/issues.html
@@ -17,9 +17,18 @@
 
 <%def name="body()">
 
+    <p class="indented">
+        <form action="markIssues" method="get">
+            <select name="action" style="margin-left:30px;margin-top:15px;margin-bottom:15px;">
+                  <option value="Delete">Delete</option>
+            </select>
+        <input type="submit" value="Go">
+    </p>
+
     <table class="display" id="book_table" style="margin-top:60px;">
         <thead>
             <tr>
+                <th id="select"><input type="checkbox" onClick="toggleAll(this)" /></th>
                 % if issues[0]['Cover'] != "images/nocover.png":
                 <th id="bookart">Cover</th>
                 % else:
@@ -34,6 +43,7 @@
         <tbody>
         %for result in issues:
                 <tr class="gradeZ">
+                    <td id="select"><input type="checkbox" name="${result['IssueFile']}" class="checkbox" /></td>
                     % if issues[0]['Cover'] != "images/nocover.png":
                     <td id="bookart"><a href="${result['Cover']}" target="_new"><img src="${result['Cover']}" height="75" width="50"></a></td>
                     % else:

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -26,7 +26,7 @@
     %if len(issues) > 0:
     <h3>Magazines with status ${whichStatus}</h3>
         <br>
-    <form action="markIssues" method="get"><input type="hidden" name="redirect" value="manageissues">
+    <form action="markPastIssues" method="get"><input type="hidden" name="redirect" value="manageissues">
     <table class="display" id="book_table">
         <thead>
             <tr>
@@ -54,14 +54,14 @@
     </table>
     <p>
 
-    Change selected magazines to <select class="markIssues" name="action" style="margin-left:30px;margin-top:15px;margin-bottom:15px;">
+    Change selected magazines to <select class="markPastIssues" name="action" style="margin-left:30px;margin-top:15px;margin-bottom:15px;">
         %for item in ['Skipped', 'Wanted', 'Ignored', 'Delete']:
             %if whichStatus != item:
                 <option value="${item}">${item}</option>
             %endif
         %endfor
             </select>
-        <input type="submit" class="markIssues" value="Go">
+        <input type="submit" class="markPastIssues" value="Go">
     </p>
     </form>
     %endif

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -158,6 +158,7 @@ NEWZBIN = 0
 NEWZBIN_UID = None
 NEWZBIN_PASSWORD = None
 EBOOK_TYPE = None
+MAG_TYPE = None
 
 TOR_DOWNLOADER_BLACKHOLE = 0
 TOR_DOWNLOADER_UTORRENT = 0
@@ -339,7 +340,7 @@ def initialize():
             ALTERNATE_DIR, GR_API, GB_API, BOOK_API, MAGICK, \
             NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, \
             NZB_DOWNLOADER_NZBGET, NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, \
-            NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, EBOOK_TYPE, KAT, KAT_HOST, \
+            NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, EBOOK_TYPE, MAG_TYPE, KAT, KAT_HOST, \
             NEWZNAB0, NEWZNAB_HOST0, NEWZNAB_API0, NEWZNAB1, NEWZNAB_HOST1, NEWZNAB_API1, \
             NEWZNAB2, NEWZNAB_HOST2, NEWZNAB_API2, NEWZNAB3, NEWZNAB_HOST3, NEWZNAB_API3, \
             NEWZNAB4, NEWZNAB_HOST4, NEWZNAB_API4, \
@@ -565,6 +566,9 @@ def initialize():
         NEWZBIN_UID = check_setting_str(CFG, 'Newzbin', 'newzbin_uid', '')
         NEWZBIN_PASS = check_setting_str(CFG, 'Newzbin', 'newzbin_pass', '')
         EBOOK_TYPE = check_setting_str(CFG, 'General', 'ebook_type', 'epub, mobi, pdf')
+        EBOOK_TYPE = EBOOK_TYPE.lower()  # to make extension matching easier
+        MAG_TYPE = check_setting_str(CFG, 'General', 'mag_type', 'pdf')
+        MAG_TYPE = MAG_TYPE.lower()  # to make extension matching easier
 
         SEARCH_INTERVAL = check_setting_int(CFG, 'SearchScan', 'search_interval', '360')
         SCAN_INTERVAL = check_setting_int(CFG, 'SearchScan', 'scan_interval', '10')
@@ -779,7 +783,8 @@ def config_write():
     CFG.set('General', 'imp_monthlang', IMP_MONTHLANG)
     CFG.set('General', 'imp_autoadd', IMP_AUTOADD)
     CFG.set('General', 'imp_convert', IMP_CONVERT)
-    CFG.set('General', 'ebook_type', EBOOK_TYPE)
+    CFG.set('General', 'ebook_type', EBOOK_TYPE.lower())
+    CFG.set('General', 'mag_type', MAG_TYPE.lower())
     CFG.set('General', 'destination_dir', DESTINATION_DIR)
     CFG.set('General', 'alternate_dir', ALTERNATE_DIR)
     CFG.set('General', 'destination_copy', DESTINATION_COPY)

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -23,13 +23,13 @@ from lazylibrarian import logger, postprocess, searchnzb, searchtorrents, \
         librarysync, versioncheck, database, searchmag, magazinescan, common
 try:
     from wand.image import Image
-    have_magick = "wand"
+    MAGICK  = "wand"
 except ImportError:
     try:
         import PythonMagick
-        have_magick = "pythonmagick"
+        MAGICK = "pythonmagick"
     except:
-        have_magick = 'convert'  # may have external, don't know yet
+        MAGICK = 'convert'  # may have external, don't know yet
 
 FULL_PATH = None
 PROG_DIR = None
@@ -270,7 +270,6 @@ CACHE_MISS = 0
 LAST_GOODREADS = 0
 LAST_LIBRARYTHING = 0
 CACHE_AGE = 30
-HAVE_MAGICK = have_magick
 
 def check_section(sec):
     """ Check if INI section exists, if not create it """
@@ -337,7 +336,7 @@ def initialize():
             MONTH8, MONTH9, MONTH10, MONTH11, MONTH12, CONFIGFILE, CFG, LOGDIR, \
             SAB_HOST, SAB_PORT, SAB_SUBDIR, SAB_API, SAB_USER, SAB_PASS, SAB_CAT, \
             DESTINATION_DIR, DESTINATION_COPY, DOWNLOAD_DIR, USENET_RETENTION, NZB_BLACKHOLEDIR, \
-            ALTERNATE_DIR, GR_API, GB_API, BOOK_API, HAVE_MAGICK, \
+            ALTERNATE_DIR, GR_API, GB_API, BOOK_API, MAGICK, \
             NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, \
             NZB_DOWNLOADER_NZBGET, NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, \
             NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, EBOOK_TYPE, KAT, KAT_HOST, \
@@ -408,7 +407,6 @@ def initialize():
         else:
             LOGFULL = False
             logger.info("Screen Log set to INFO/WARN/ERROR")
-        logger.debug("HAVE_MAGICK set to %s" % HAVE_MAGICK)
 
         # keep track of last api calls so we don't call more than once per second
         # to respect api terms, but don't wait un-necessarily either

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -121,8 +121,8 @@ def is_valid_isbn(isbn):
     return False
 
 
-def is_valid_booktype(filename, filetype=None):
-    if filetype == 'mag':  # default is book
+def is_valid_booktype(filename, booktype=None):
+    if booktype == 'mag':  # default is book
         booktype_list = getList(lazylibrarian.MAG_TYPE)
     else:
         booktype_list = getList(lazylibrarian.EBOOK_TYPE)

--- a/lazylibrarian/formatter.py
+++ b/lazylibrarian/formatter.py
@@ -121,12 +121,15 @@ def is_valid_isbn(isbn):
     return False
 
 
-def is_valid_booktype(filename):
-    booktype_list = getList(lazylibrarian.EBOOK_TYPE)
+def is_valid_booktype(filename, filetype=None):
+    if filetype == 'mag':  # default is book
+        booktype_list = getList(lazylibrarian.MAG_TYPE)
+    else:
+        booktype_list = getList(lazylibrarian.EBOOK_TYPE)
     if '.' in filename:
         words = filename.split('.')
         extn = words[len(words) - 1]
-        if extn in booktype_list:
+        if extn.lower() in booktype_list:
             return True
     return False
 

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -85,8 +85,8 @@ def magazineScan(thread=None):
 
     for dirname, dirnames, filenames in os.walk(mag_path):
         for fname in filenames[:]:
-            # if fname.endswith('.pdf'): maybe not all magazines will be pdf?
-            if formatter.is_valid_booktype(fname):
+            # maybe not all magazines will be pdf?
+            if formatter.is_valid_magtype(fname):
                 try:
                     title = fname.split('-')[3]
                     title = title.split('.')[-2]

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -16,7 +16,13 @@ except ImportError:
 def create_cover(issuefile=None):
     if not lazylibrarian.IMP_CONVERT == 'None':  # special flag to say "no covers required"
         # create a thumbnail cover if there isn't one
-        coverfile = issuefile.replace('.pdf', '.jpg')
+        if '.' in issuefile:
+            words = issuefile.split('.')
+            extn = '.' + words[len(words) - 1]
+            coverfile = issuefile.replace(extn, '.jpg')
+        else:
+            logger.debug('Unable to create cover for %s, no extension?' % issuefile)
+            return
         if not os.path.isfile(coverfile):
             logger.debug("Creating cover for %s using %s" % (issuefile, lazylibrarian.MAGICK))
             try:
@@ -86,7 +92,7 @@ def magazineScan(thread=None):
     for dirname, dirnames, filenames in os.walk(mag_path):
         for fname in filenames[:]:
             # maybe not all magazines will be pdf?
-            if formatter.is_valid_magtype(fname):
+            if formatter.is_valid_booktype(fname, booktype='mag'):
                 try:
                     title = fname.split('-')[3]
                     title = title.split('.')[-2]

--- a/lazylibrarian/magazinescan.py
+++ b/lazylibrarian/magazinescan.py
@@ -4,43 +4,44 @@ import lazylibrarian
 import threading
 import subprocess
 from lazylibrarian import database, logger, formatter, notifiers, common
+try:
+    from wand.image import Image
+except ImportError:
+    try:
+        import PythonMagick
+    except:
+        lazylibrarian.MAGICK = 'convert'  # may have external, don't know yet
 
 
 def create_cover(issuefile=None):
-    if lazylibrarian.HAVE_MAGICK:
+    if not lazylibrarian.IMP_CONVERT == 'None':  # special flag to say "no covers required"
         # create a thumbnail cover if there isn't one
         coverfile = issuefile.replace('.pdf', '.jpg')
         if not os.path.isfile(coverfile):
-            logger.debug("Creating cover for %s" % issuefile)
+            logger.debug("Creating cover for %s using %s" % (issuefile, lazylibrarian.MAGICK))
             try:
                 # No PythonMagick in python3, hence allow wand, but more complicated
                 # to install - try to use external imagemagick convert?
                 # should work on win/mac/linux as long as imagemagick is installed
                 # and config points to external "convert" program
-                program = 'none detected'
+
                 if len(lazylibrarian.IMP_CONVERT):  # allow external convert to override libraries
-                    program = lazylibrarian.IMP_CONVERT
                     try:
-                        params = [program, issuefile + '[0]', coverfile]
-                        subprocess.check_call(params)
-                    except subprocess.CalledProcessError:
-                        logger.warn('No ImageMagick "convert" found')
-                        lazylibrarian.HAVE_MAGICK = ""  # don't keep trying
+                        params = [lazylibrarian.IMP_CONVERT, issuefile + '[0]', coverfile]
+                        subprocess.check_output(params, stderr=subprocess.STDOUT)
+                    except subprocess.CalledProcessError, e:
+                        logger.warn('ImageMagick "convert" failed %s' % e.output)
                         
-                elif lazylibrarian.HAVE_MAGICK == 'wand':
-                    program = 'Wand library'
-                    from wand.image import Image
+                elif lazylibrarian.MAGICK == 'wand':
                     with Image(filename=issuefile + '[0]') as img:
                         img.save(filename=coverfile)
                         
-                elif lazylibrarian.HAVE_MAGICK == 'pythonmagick':
-                    program = 'PythonMagick library'
-                    import PythonMagick
+                elif lazylibrarian.MAGICK == 'pythonmagick':
                     img = PythonMagick.Image()
                     img.read(issuefile + '[0]')
                     img.write(coverfile)
             except:
-                logger.debug("Unable to create cover for %s using %s" % (issuefile, program))
+                logger.debug("Unable to create cover for %s using %s" % (issuefile, lazylibrarian.MAGICK))
 
 def magazineScan(thread=None):
     # rename this thread

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -149,10 +149,10 @@ def processDir(force=False):
             dic = {'<': '', '>': '', '...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's',
                    ' + ': ' ', '"': '', ',': '', '*': '', ':': '', ';': '', '\'': ''}
             dest_path = formatter.latinToAscii(formatter.replace_all(dest_path, dic))
-            try:
-                os.chmod(dest_path, 0777)
-            except Exception, e:
-                logger.debug("Could not chmod post-process directory: " + str(dest_path))
+            #try:
+            #    os.chmod(dest_path, 0777)
+            #except Exception, e:
+            #    logger.debug("Could not chmod post-process directory: " + str(dest_path))
 
             processBook = processDestination(pp_path, dest_path, authorname, bookname, global_name, book['BookID'])
 
@@ -225,11 +225,11 @@ def import_book(pp_path=None, bookID=None):
         authorname = data[0]['AuthorName']
         bookname = data[0]['BookName']
 
-        try:
-            auth_dir = os.path.join(lazylibrarian.DESTINATION_DIR, authorname).encode(lazylibrarian.SYS_ENCODING)
-            os.chmod(auth_dir, 0777)
-        except Exception, e:
-            logger.debug("Could not chmod author directory: " + str(auth_dir))
+        #try:
+        #    auth_dir = os.path.join(lazylibrarian.DESTINATION_DIR, authorname).encode(lazylibrarian.SYS_ENCODING)
+        #    os.chmod(auth_dir, 0777)
+        #except Exception, e:
+        #    logger.debug("Could not chmod author directory: " + str(auth_dir))
 
         dest_path = lazylibrarian.EBOOK_DEST_FOLDER.replace('$Author', authorname).replace('$Title', bookname)
         global_name = lazylibrarian.EBOOK_DEST_FILE.replace('$Author', authorname).replace('$Title', bookname)
@@ -364,10 +364,10 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
                     logger.debug('Moving %s to directory %s' % (file2, dest_path))
                     os.rename(os.path.join(dest_path, file2), os.path.join(dest_path, global_name + '.' +
                               str(file2).split('.')[-1]))
-        try:
-            os.chmod(dest_path, 0777)
-        except Exception, e:
-            logger.debug("Could not chmod path: " + str(dest_path))
+        #try:
+        #    os.chmod(dest_path, 0777)
+        #except Exception, e:
+        #    logger.debug("Could not chmod path: " + str(dest_path))
     except OSError, e:
         logger.error('Could not create destination folder or rename the downloaded ebook. Check permissions of: ' +
                      lazylibrarian.DESTINATION_DIR)
@@ -418,14 +418,13 @@ def processIMG(dest_path=None, bookimg=None, global_name=None):
         if not bookimg == ('images/nocover.png'):
             logger.debug('Downloading cover from ' + bookimg)
             coverpath = os.path.join(dest_path, global_name + '.jpg')
-            img = open(coverpath, 'wb')
-            imggoogle = imgGoogle()
-            img.write(imggoogle.open(bookimg).read())
-            img.close()
-            try:
-                os.chmod(coverpath, 0777)
-            except Exception, e:
-                logger.error("Could not chmod path: " + str(coverpath))
+            with open(coverpath, 'wb') as img:
+                imggoogle = imgGoogle()
+                img.write(imggoogle.open(bookimg).read())
+            #try:
+            #    os.chmod(coverpath, 0777)
+            #except Exception, e:
+            #    logger.error("Could not chmod path: " + str(coverpath))
 
     except (IOError, EOFError), e:
         logger.error('Error fetching cover from url: %s, %s' % (bookimg, e))
@@ -466,15 +465,12 @@ def processOPF(dest_path=None, authorname=None, bookname=None, bookisbn=None, bo
     # handle metadata
     opfpath = os.path.join(dest_path, global_name + '.opf')
     if not os.path.exists(opfpath):
-        opf = open(opfpath, 'wb')
-        opf.write(opfinfo)
-        opf.close()
-
-        try:
-            os.chmod(opfpath, 0777)
-        except Exception, e:
-            logger.error("Could not chmod path: " + str(opfpath))
-
+        with open(opfpath, 'wb') as opf:
+            opf.write(opfinfo)
+        #try:
+        #    os.chmod(opfpath, 0777)
+        #except Exception, e:
+        #    logger.error("Could not chmod path: " + str(opfpath))
         logger.debug('Saved metadata to: ' + opfpath)
     else:
         logger.debug('%s allready exists. Did not create one.' % opfpath)

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -142,11 +142,13 @@ def search_magazines(mags=None):
                                 name_match = 0  # name match failed
                     if name_match:
                         # some magazine torrent uploaders add their sig in [] or {}
-                        if nzbtitle_exploded[len(nzbtitle_exploded) - 1][0] in '[{':
-                            nzbtitle_exploded.pop()  # gotta love the function names
-                        # some magazine torrent titles are "magazine name some form of date .pdf"
-                        if nzbtitle_exploded[len(nzbtitle_exploded) - 1].lower() == 'pdf':
-                            nzbtitle_exploded.pop()
+                        # Fortunately for us, they always seem to add it at the end
+                        # some magazine torrent titles are "magazine_name some_form_of_date pdf"
+                        # so strip all the trailing junk...
+                        while nzbtitle_exploded[len(nzbtitle_exploded) - 1][0] in '[{' or \
+                            nzbtitle_exploded[len(nzbtitle_exploded) - 1].lower() == 'pdf':
+                                nzbtitle_exploded.pop()  # gotta love the function names
+                        
                         if len(nzbtitle_exploded) > 1:
                             # regexA = DD MonthName YYYY OR MonthName YYYY or nn MonthName YYYY
                             regexA_year = nzbtitle_exploded[len(nzbtitle_exploded) - 1]

--- a/lazylibrarian/searchmag.py
+++ b/lazylibrarian/searchmag.py
@@ -141,12 +141,18 @@ def search_magazines(mags=None):
                                              ratio, bookid, nzbtitle_formatted))
                                 name_match = 0  # name match failed
                     if name_match:
-                            # some magazine torrent titles are "magazine name some form of date .pdf"
-                        if nzbtitle_exploded[len(nzbtitle_exploded) - 1].lower() == 'pdf':
+                        # some magazine torrent uploaders add their sig in [] or {}
+                        if nzbtitle_exploded[len(nzbtitle_exploded) - 1][0] in '[{':
                             nzbtitle_exploded.pop()  # gotta love the function names
+                        # some magazine torrent titles are "magazine name some form of date .pdf"
+                        if nzbtitle_exploded[len(nzbtitle_exploded) - 1].lower() == 'pdf':
+                            nzbtitle_exploded.pop()
                         if len(nzbtitle_exploded) > 1:
                             # regexA = DD MonthName YYYY OR MonthName YYYY or nn MonthName YYYY
                             regexA_year = nzbtitle_exploded[len(nzbtitle_exploded) - 1]
+                            if regexA_year.isdigit():
+                                if int(regexA_year) < 1900 or int(regexA_year) > 2100:
+                                    regexA_year = 'Invalid'
                             regexA_month_temp = nzbtitle_exploded[len(nzbtitle_exploded) - 2]
                             regexA_month = formatter.month2num(common.remove_accents(regexA_month_temp))
 
@@ -159,7 +165,7 @@ def search_magazines(mags=None):
                                     regexA_day = '01'  # just MonthName YYYY
                             else:
                                 regexA_day = '01'  # monthly, or less frequent
-
+                            
                             newdatish_regexA = regexA_year + regexA_month + regexA_day
 
                             try:
@@ -182,7 +188,7 @@ def search_magazines(mags=None):
                                     newdatish_regexC = 'Invalid'  # invalid unless works out otherwise
                                     regexC_temp = nzbtitle_exploded[len(nzbtitle_exploded) - 2]
                                     if regexC_temp.isdigit():
-                                        if int(regexC_temp) > 1900:  # YYYY MM  or YYYY nn
+                                        if int(regexC_temp) > 1900 and int(regexC_temp) < 2100:  # YYYY MM  or YYYY nn
                                             regexC_year = regexC_temp
                                             regexC_month = nzbtitle_exploded[len(nzbtitle_exploded) - 1].zfill(2)
                                             regexC_day = '01'
@@ -193,7 +199,7 @@ def search_magazines(mags=None):
                                         else:
                                             regexC_year = nzbtitle_exploded[len(nzbtitle_exploded) - 3]
                                             if regexC_year.isdigit():
-                                                if int(regexC_year) > 1900:  # YYYY MM DD or YYYY nn-nn
+                                                if int(regexC_year) > 1900 and int(regexC_year) < 2100:  # YYYY MM DD or YYYY nn-nn
                                                     regexC_month = regexC_temp.zfill(2)
                                                     if int(regexC_month) < 13:
                                                         # if issue number > 12 date matching will fail
@@ -242,7 +248,7 @@ def search_magazines(mags=None):
                             start_time = time.time()
                             start_time -= 31 * 24 * 60 * 60  # number of seconds in 31 days
                             control_date = time.strftime("%Y-%m-%d", time.localtime(start_time))
-
+                        print nzbtitle,newdatish
                         # only grab a copy if it's newer than the most recent we have,
                         # or newer than a month ago if we have none
                         comp_date = formatter.datecompare(newdatish, control_date)

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -187,10 +187,10 @@ def NZBDownloadMethod(bookid=None, nzbprov=None, nzbtitle=None, nzburl=None):
                     f.write(nzbfile)
                 logger.debug('NZB file saved to: ' + nzbpath)
                 download = True
-                try:
-                    os.chmod(nzbpath, 0777)
-                except Exception, e:
-                    logger.error("Could not chmod path: " + str(nzbpath))
+                #try:
+                #    os.chmod(nzbpath, 0777)
+                #except Exception, e:
+                #    logger.error("Could not chmod path: " + str(nzbpath))
             except Exception, e:
                 logger.error('%s not writable, NZB not saved. Error: %s' % (nzbpath, e))
                 download = False

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -77,7 +77,7 @@ class WebInterface(object):
                      newznab_api0=None, newznab1=0, newznab_host1=None, newznab_api1=None, newznab2=0,
                      newznab_host2=None, newznab_api2=None, newznab3=0, newznab_host3=None, newznab_api3=None,
                      newznab4=0, newznab_host4=None, newznab_api4=None, newzbin=0, newzbin_uid=None,
-                     newzbin_pass=None, kat=0, kat_host=None, ebook_type=None, book_api=None,
+                     newzbin_pass=None, kat=0, kat_host=None, ebook_type=None, mag_type=None, book_api=None,
                      torznab0=0, torznab_host0=None, torznab_api0=None, torznab1=0, torznab_host1=None,
                      torznab_api1=None, torznab2=0, torznab_host2=None, torznab_api2=None,
                      torznab3=0, torznab_host3=None, torznab_api3=None, torznab4=0, torznab_host4=None,
@@ -214,6 +214,7 @@ class WebInterface(object):
         lazylibrarian.USE_TOR = bool(use_tor)
 
         lazylibrarian.EBOOK_TYPE = ebook_type
+        lazylibrarian.MAG_TYPE = mag_type
         lazylibrarian.BOOK_API = book_api
         lazylibrarian.GR_API = gr_api
         lazylibrarian.GB_API = gb_api

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -622,19 +622,25 @@ class WebInterface(object):
             mod_issues = []
             for issue in issues:
                 magfile = issue['IssueFile']
-                magimg = magfile.replace('.pdf', '.jpg')
-                if not os.path.isfile(magimg):
-                    magimg = 'images/nocover.png'
+                if '.' in magfile:
+                    words = magfile.split('.')
+                    extn = '.' + words[len(words) - 1]
+                    magimg = magfile.replace(extn, '.jpg')
+                    if not os.path.isfile(magimg):
+                        magimg = 'images/nocover.png'
+                    else:
+                        myhash = hashlib.md5(magimg).hexdigest()
+                        cachedir = os.path.join(str(lazylibrarian.PROG_DIR),
+                                                'data' + os.sep + 'images' + os.sep + 'cache')
+                        if not os.path.isdir(cachedir):
+                            os.makedirs(cachedir)
+                        hashname = os.path.join(cachedir, myhash + ".jpg")
+                        shutil.copyfile(magimg, hashname)
+                        magimg = 'images/cache/' + myhash + '.jpg'
                 else:
-                    myhash = hashlib.md5(magimg).hexdigest()
-                    cachedir = os.path.join(str(lazylibrarian.PROG_DIR),
-                                            'data' + os.sep + 'images' + os.sep + 'cache')
-                    if not os.path.isdir(cachedir):
-                        os.makedirs(cachedir)
-                    hashname = os.path.join(cachedir, myhash + ".jpg")
-                    shutil.copyfile(magimg, hashname)
-                    magimg = 'images/cache/' + myhash + '.jpg'
-
+                    logger.debug('No extension found on %s' % magfile)
+                    magimg = 'images/nocover.png'
+                
                 this_issue = dict(issue)
                 this_issue['Cover'] = magimg
                 mod_issues.append(this_issue)


### PR DESCRIPTION
Ensure ebook_types are lowercase for extension matching.
Separated out ebook_types and mag_types so users don't have to enable pdf books 
to let magazines work (which are mainly pdf)
Added 'delete' button to issues page. Only deletes entry in database, not magazine file.
Match more dates in magazines with extras in title, eg uploader names