### PR TITLE
Add https support to web server

### DIFF
--- a/LazyLibrarian.py
+++ b/LazyLibrarian.py
@@ -152,6 +152,9 @@ def main():
         'http_root': lazylibrarian.HTTP_ROOT,
         'http_user': lazylibrarian.HTTP_USER,
         'http_pass': lazylibrarian.HTTP_PASS,
+        'https_enabled': lazylibrarian.HTTPS_ENABLED,
+        'https_cert': lazylibrarian.HTTPS_CERT,
+        'https_key': lazylibrarian.HTTPS_KEY,
     })
 
     if lazylibrarian.LAUNCH_BROWSER and not options.nolaunch:

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -38,8 +38,21 @@
                   <div>
                   <label>Port:</label><input type="text" name="http_port" value="${lazylibrarian.HTTP_PORT}" size="10" maxlength="40">
                   </div>
-		  <label>Web Root:</label><input type="text" name="http_root" value="${lazylibrarian.HTTP_ROOT}" size="20" maxlength="40">
-		  </div>
+                  <label>Web Root:</label><input type="text" name="http_root" value="${lazylibrarian.HTTP_ROOT}" size="20" maxlength="40">
+                    <%
+                        if lazylibrarian.HTTPS_ENABLED == True:
+                            checked = 'checked="checked"'
+                        else:
+                            checked = ''
+                    %>
+                    <BR>
+                    <input type="checkbox" name="https_enabled" value=1 ${checked} />
+                    <label>  Enable Https</label>
+                  <br>
+                  <label>Https Certificate:</label><input type="text" name="https_cert" value="${lazylibrarian.HTTPS_CERT}" size="20">
+		          <br>
+                  <label>Https Key:</label><input type="text" name="https_key" value="${lazylibrarian.HTTPS_KEY}" size="20">
+		          </div>
                   <br>
                   <br>
                   <label>Logdir:</label><input type="text" name="logdir" value="${lazylibrarian.LOGDIR}" size="26"><br>

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -81,6 +81,9 @@ HTTP_USER = None
 HTTP_PASS = None
 HTTP_ROOT = None
 HTTP_LOOK = None
+HTTPS_ENABLED = 0
+HTTPS_CERT = None
+HTTPS_KEY = None
 LAUNCH_BROWSER = 0
 API_ENABLED = 0
 API_KEY = None
@@ -418,7 +421,8 @@ def config_read(reloaded=False):
             GIT_USER, GIT_REPO, GIT_BRANCH, INSTALL_TYPE, CURRENT_VERSION, \
             LATEST_VERSION, COMMITS_BEHIND, NUMBEROFSEEDERS, SCHED, CACHE_HIT, CACHE_MISS, \
             BOOKSTRAP_THEME, \
-            LOGFILES, LOGSIZE
+            LOGFILES, LOGSIZE, \
+            HTTPS_ENABLED, HTTPS_CERT, HTTPS_KEY
 
         NEWZNAB_PROV = []
         TORZNAB_PROV = []
@@ -445,6 +449,9 @@ def config_read(reloaded=False):
         HTTP_PASS = check_setting_str(CFG, 'General', 'http_pass', '')
         HTTP_ROOT = check_setting_str(CFG, 'General', 'http_root', '')
         HTTP_LOOK = check_setting_str(CFG, 'General', 'http_look', 'default')
+        HTTPS_ENABLED = check_setting_bool(CFG, 'General', 'https_enabled', 0)
+        HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', '')
+        HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', '')
         BOOKSTRAP_THEME = check_setting_str(CFG, 'General', 'bookstrap_theme', 'slate')
 
         LAUNCH_BROWSER = check_setting_bool(CFG, 'General', 'launch_browser', 1)
@@ -775,6 +782,9 @@ def config_write():
     CFG.set('General', 'http_pass', HTTP_PASS)
     CFG.set('General', 'http_root', HTTP_ROOT)
     CFG.set('General', 'http_look', HTTP_LOOK)
+    CFG.set('General', 'https_enabled', HTTPS_ENABLED)
+    CFG.set('General', 'https_cert', HTTPS_CERT)
+    CFG.set('General', 'https_key', HTTPS_KEY)
     CFG.set('General', 'bookstrap_theme', BOOKSTRAP_THEME)
     CFG.set('General', 'launch_browser', LAUNCH_BROWSER)
     CFG.set('General', 'api_enabled', API_ENABLED)

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -103,7 +103,8 @@ class WebInterface(object):
                      pushover_apitoken='', pushover_ondownload=0, pushover_device='',
                      use_androidpn=0, androidpn_notify_onsnatch=0, androidpn_notify_ondownload=0,
                      androidpn_url='', androidpn_username='', androidpn_broadcast=0, bookstrap_theme='',
-                     use_nma=0, nma_apikey='', nma_priority=0, nma_onsnatch=0, nma_ondownload=0, **kwargs):
+                     use_nma=0, nma_apikey='', nma_priority=0, nma_onsnatch=0, nma_ondownload=0, 
+                     https_enabled=0, https_cert='', https_key='', **kwargs):
         #  print len(kwargs)
         #  for arg in kwargs:
         #      print arg
@@ -113,6 +114,9 @@ class WebInterface(object):
         lazylibrarian.HTTP_USER = http_user
         lazylibrarian.HTTP_PASS = http_pass
         lazylibrarian.HTTP_LOOK = http_look
+        lazylibrarian.HTTPS_ENABLED = bool(https_enabled)
+        lazylibrarian.HTTPS_CERT = https_cert
+        lazylibrarian.HTTPS_KEY = https_key
         lazylibrarian.BOOKSTRAP_THEME = bookstrap_theme
         lazylibrarian.LAUNCH_BROWSER = bool(launch_browser)
         lazylibrarian.API_ENABLED = bool(api_enabled)

--- a/lazylibrarian/webStart.py
+++ b/lazylibrarian/webStart.py
@@ -3,12 +3,22 @@ import sys
 import cherrypy
 import lazylibrarian
 
+from lazylibrarian import logger
 from lazylibrarian.webServe import WebInterface
 
 
 def initialize(options={}):
 
-    cherrypy.config.update({
+    https_enabled = options['https_enabled']
+    https_cert = options['https_cert']
+    https_key = options['https_key']
+
+    if https_enabled:
+        if not (os.path.exists(https_cert) and os.path.exists(https_key)):
+            logger.warn("Disabled HTTPS because of missing certificate and key.")
+            https_enabled = False
+    
+    options_dict = {
         'log.screen': False,
         'server.thread_pool': 10,
         'server.socket_port': options['http_port'],
@@ -17,7 +27,18 @@ def initialize(options={}):
         'tools.encode.on': True,
         'tools.encode.encoding': 'utf-8',
         'tools.decode.on': True,
-    })
+    }
+    
+    if https_enabled:
+        options_dict['server.ssl_certificate'] = https_cert
+        options_dict['server.ssl_private_key'] = https_key
+        protocol = "https"
+    else:
+        protocol = "http"
+        
+    logger.info("Starting LazyLibrarian web server on %s://%s:%d/" %
+            (protocol, options['http_host'], options['http_port']))
+    cherrypy.config.update(options_dict)
 
     conf = {
         '/': {


### PR DESCRIPTION
* Option to enable/disable https for cherrypy web server
* Need to specify location of certificate/key in the settings