### PR TITLE
Added Kickass and PirateBay mirrors for torrents

### DIFF
--- a/data/interfaces/bookstrap/config.html
+++ b/data/interfaces/bookstrap/config.html
@@ -726,6 +726,21 @@
                                                 <input type="text" placeholder="KAT Host" id="kat_host" name="kat_host" value="${lazylibrarian.KAT_HOST}" class="form-control">
                                             </div>
                                         </div>
+                                        <%
+                                        if lazylibrarian.TPB == True:
+                                            checked = 'checked="checked"'
+                                        else:
+                                            checked = ''
+                                        %>
+                                        <div class="form-group">
+                                            <label for="tpb_host" class="sr-only">TPB Host</label>
+                                            <div class="input-group">
+                                                <span class="input-group-addon">
+                                                    <input type="checkbox" id="tpb" name="tpb" value="1" ${checked} />
+                                                </span>
+                                                <input type="text" placeholder="TPB Host" id="tpb_host" name="tpb_host" value="${lazylibrarian.TPB_HOST}" class="form-control">
+                                            </div>
+                                        </div>
                                     </fieldset>
                                 </div>
                             </div>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -574,6 +574,15 @@
                     %>
             		<input type="checkbox" name="kat" value=1 ${checked} style="margin-bottom:4px;" /> KAT
  	    		    <input type="text" placeholder="Enter URL Here" name="kat_host" value="${lazylibrarian.KAT_HOST}" size="26">
+ 	  		        <br>
+ 	  		        <%
+                    if lazylibrarian.TPB == True:
+                        checked = 'checked="checked"'
+                    else:
+                        checked = ''
+                    %>
+            		<input type="checkbox" name="tpb" value=1 ${checked} style="margin-bottom:4px;" /> TPB
+ 	    		    <input type="text" placeholder="Enter URL Here" name="tpb_host" value="${lazylibrarian.TPB_HOST}" size="26">
  	    		</td>
             </tr>
         </table>

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -174,6 +174,8 @@ DELUGE_LABEL = None
 
 KAT = 0
 KAT_HOST = None
+TPB = 0
+TPB_HOST = None
 
 NZB_DOWNLOADER_SABNZBD = 0
 NZB_DOWNLOADER_NZBGET = 0
@@ -407,7 +409,7 @@ def config_read(reloaded=False):
             ALTERNATE_DIR, GR_API, GB_API, BOOK_API, MAGICK, \
             NZBGET_HOST, NZBGET_USER, NZBGET_PASS, NZBGET_CATEGORY, NZBGET_PRIORITY, \
             NZBGET_PORT, NZB_DOWNLOADER_NZBGET, NZBMATRIX, NZBMATRIX_USER, NZBMATRIX_API, \
-            NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, EBOOK_TYPE, MAG_TYPE, KAT, KAT_HOST, \
+            NEWZBIN, NEWZBIN_UID, NEWZBIN_PASS, EBOOK_TYPE, MAG_TYPE, KAT, KAT_HOST, TPB, TPB_HOST,\
             NEWZNAB_PROV, TORZNAB_PROV, RSS_PROV, REJECT_WORDS, REJECT_MAXSIZE, \
             VERSIONCHECK_INTERVAL, SEARCH_INTERVAL, SCAN_INTERVAL, SEARCHRSS_INTERVAL, \
             EBOOK_DEST_FOLDER, EBOOK_DEST_FILE, MAG_RELATIVE, MAG_DEST_FOLDER, MAG_DEST_FILE, \
@@ -710,7 +712,9 @@ def config_read(reloaded=False):
         DELUGE_LABEL = check_setting_str(CFG, 'DELUGE', 'deluge_label', '')
 
         KAT = check_setting_bool(CFG, 'KAT', 'kat', 0)
-        KAT_HOST = check_setting_str(CFG, 'KAT', 'kat_host', 'kat.cr')
+        KAT_HOST = check_setting_str(CFG, 'KAT', 'kat_host', 'kickass.cd')
+        TPB = check_setting_bool(CFG, 'TPB', 'tpb', 0)
+        TPB_HOST = check_setting_str(CFG, 'TPB', 'tpb_host', 'https://piratebays.co')
 
         NEWZBIN = check_setting_bool(CFG, 'Newzbin', 'newzbin', 0)
         NEWZBIN_UID = check_setting_str(CFG, 'Newzbin', 'newzbin_uid', '')
@@ -970,6 +974,10 @@ def config_write():
     CFG.set('KAT', 'kat', KAT)
     CFG.set('KAT', 'kat_host', KAT_HOST)
 #
+    check_section('TPB')
+    CFG.set('TPB', 'tpb', TPB)
+    CFG.set('TPB', 'tpb_host', TPB_HOST)
+#
     check_section('SearchScan')
     CFG.set('SearchScan', 'search_interval', SEARCH_INTERVAL)
     CFG.set('SearchScan', 'scan_interval', SCAN_INTERVAL)
@@ -1135,6 +1143,8 @@ def USE_RSS():
 
 def USE_TOR():
     if bool(KAT):
+        return True
+    if bool(TPB):
         return True
     return False
 

--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -661,6 +661,8 @@ class GoogleBooks:
         except KeyError:
             bookpub = None
 
+        series = None
+        seriesNum = None
         try:
             booksub = jsonresults['volumeInfo']['subtitle']
             try:

--- a/lazylibrarian/providers.py
+++ b/lazylibrarian/providers.py
@@ -103,9 +103,13 @@ def TPB(book=None):
                             #except IndexError:
                             #    age = None
                             try:
-                                size = float(line.split('class="detDesc"')[1].split('Size ')[1].split('KiB')[0].decode('ascii', 'ignore'))
+                                size = line.split('class="detDesc"')[1].split('Size ')[1].split('KiB')[0].decode('ascii', 'ignore')
+                                try:
+                                    size = float(size) * 1024
+                                except ValueError:
+                                    size = 0
                             except IndexError:
-                                size = None
+                                size = 0
                         cur += 1
 
                     try:
@@ -230,6 +234,10 @@ def KAT(book=None):
                         cur += 1
                     try:
                         size = lines[fin-4].split('</td>')[0].split('>')[1].split('&')[0].strip()
+                        try:
+                            size = float(size) * 1024
+                        except ValueError:
+                            size = 0
                     except IndexError:
                         size = 0
                     #try:

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -114,7 +114,7 @@ class WebInterface(object):
                      nzb_blackholedir='', alternate_dir='', torrent_dir='', numberofseeders=0,
                      tor_downloader_blackhole=0, tor_downloader_utorrent=0, tor_downloader_qbittorrent=0,
                      nzbget_host='', nzbget_port=0, nzbget_user='', nzbget_pass='', nzbget_cat='', nzbget_priority=0,
-                     newzbin=0, newzbin_uid='', newzbin_pass='', kat=0, kat_host='',
+                     newzbin=0, newzbin_uid='', newzbin_pass='', kat=0, kat_host='', tpb=0, tpb_host='',
                      ebook_type='', mag_type='', reject_words='', reject_maxsize=0,
                      book_api='', gr_api='', gb_api='',
                      versioncheck_interval='', search_interval='', scan_interval='', searchrss_interval=20,
@@ -238,6 +238,8 @@ class WebInterface(object):
 
         lazylibrarian.KAT = bool(kat)
         lazylibrarian.KAT_HOST = kat_host
+        lazylibrarian.TPB = bool(tpb)
+        lazylibrarian.TPB_HOST = tpb_host
 
         lazylibrarian.EBOOK_TYPE = ebook_type
         lazylibrarian.MAG_TYPE = mag_type


### PR DESCRIPTION
Seems KAT mirrors are not offering rss, may be a temporary problem? They just return html even using the rss buttons on the webpages.

As a workaround, added parsing of html pages from Kickass and PirateBay mirrors.
Currently tested and working with kickass.cd  and https://piratebays.co
note: need to use   https  for piratebay 

