### PR TITLE
Added editing feature for book details

### DIFF
--- a/data/interfaces/bookstrap/author.html
+++ b/data/interfaces/bookstrap/author.html
@@ -5,7 +5,7 @@
 
 <%def name="headerIncludes()">
     <div id="subhead_container">
-        <form id="subhead_menu" class="form-inline">            
+        <form id="subhead_menu" class="form-inline">
             <a href="refreshAuthor?AuthorID=${author['AuthorID']}" class="btn btn-sm btn-primary"><i class="fa fa-refresh"></i> Refresh Author</a>
             <a href="deleteAuthor?AuthorID=${author['AuthorID']}" class="btn btn-sm btn-primary"><i class="fa fa-remove"></i> Delete Author</a>
             %if author['Status'] == 'Paused':
@@ -23,7 +23,7 @@
                         <option value="${language['BookLang']}">${language['BookLang']}</option>
                         %endfor
                     </select>
-                </div>            
+                </div>
             %endif
         </form>
     </div>
@@ -80,9 +80,9 @@
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" aria-valuenow="${percent}" aria-valuemin="0" aria-valuemax="100" style="width: ${percent}%;">
                         <span class="sr-only">${percent}% Complete</span>
-                    </div>                    
+                    </div>
                 </div>
-                </div>                
+                </div>
                 <div class="col-xs-4">
                     <span class="progressbar-front-text">${havebooks} / ${totalbooks}</span>
                 </div>
@@ -91,9 +91,9 @@
     </div>
 </div>
 
-<form action="markBooks" method="get" class="form-inline">            
+<form action="markBooks" method="get" class="form-inline">
     <div class="indented">
-        
+
             <input type="hidden" name="AuthorID" value="${author['AuthorID']}">
             <input type="hidden" name="redirect" value="author">
             <div class="form-group">
@@ -103,10 +103,10 @@
                     <option value="Have">Have</option>
                     <option value="Skipped">Skipped</option>
                     <option value="Ignored">Ignored</option>
-                </select>                
+                </select>
             </div>
             <input type="submit" class="markBooks btn btn-sm btn-primary" value="Go">
-        
+
     </div>
     <p>&nbsp;</p>
 <div class="table-responsive">
@@ -144,19 +144,25 @@
                         starimg = '5-stars.png'
                     else:
                         starimg = '0-stars.png'
+
+                    if 'goodreads' in result['booklink']:
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoodReads</i></a>'
+                    if 'google' in result['booklink']:
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoogleBooks</i></a>'
+
                     workpage = ''
                     if result['workpage']:
                         if len(result['workpage']) > 4:
-                            workpage = '<br><a href="' + result['workpage'] + '" target="_new">WorkPage</a>' 
+                            workpage = '<a href="' + result['workpage'] + '" target="_new"><i class="smalltext">LibraryThing</i></a>'
                 %>
                 <tr>
                     <td class="select"><input type="checkbox" name="${result['BookID']}" /></td>
                     <td class="bookart text-center"><a href="${result['bookimg']}" target="_blank" rel="noreferrer"><img src="${result['bookimg']}" class="bookcover-xs img-responsive" alt="Cover"></a></td>
                     %if result['booksub']:
-                        <td class id="bookname"><a href="${result['booklink']}" target="_blank" rel="noreferrer">${result['bookname']}</a><br>
-                        <i class="smalltext">${result['booksub']}</i></td>
+                        <td class id="bookname">${result['bookname']}<br>
+                        <i class="smalltext">${result['booksub']}</i><br>${workpage}&nbsp;${sitelink}</td>
                     %else:
-                        <td class="bookname"><a href="${result['booklink']}" target="_blank" rel="noreferrer">${result['bookname']}</a></td>
+                        <td class="bookname">${result['bookname']}<br>${workpage}&nbsp;${sitelink}</td>
                     %endif
                     <td class="series">${result['Series']}</td>
                     <td class="seriesNum text-center">${result['seriesNum']}</td>
@@ -165,21 +171,21 @@
                     <td class="language text-center">${result['booklang']}</td>
 
                     %if result['Status'] == 'Open':
-                        <td class="status text-center"><a class="btn btn-xs btn-warning button green" href="openBook?bookid=${result['bookID']}" target="_self"><i class="fa fa-book"></i> ${result['Status']}</a>${workpage}</td>
+                        <td class="status text-center"><a class="btn btn-xs btn-warning button green" href="openBook?bookid=${result['bookID']}" target="_self"><i class="fa fa-book"></i> ${result['Status']}</a></td>
                     %else:
                         %if result['Status'] == 'Wanted':
                             <td class="status text-center">
                                 <!--<p><a class="btn btn-xs btn-danger" href="searchForBook?bookid=${result['bookID']}" target="_self"></p>-->
                                 <p><a class="a btn btn-xs btn-danger">${result['Status']}</a></p>
-                                <p><a class="b btn btn-xs btn-success" href="searchForBook?bookid=${result['bookID']}" title="Search Now"><i class="fa fa-search"></i> Search</a></p>${workpage}</td>
+                                <p><a class="b btn btn-xs btn-success" href="searchForBook?bookid=${result['bookID']}" title="Search Now"><i class="fa fa-search"></i> Search</a></p></td>
                         %else:
                             %if result['Status'] == 'Snatched':
-                                <td class="status text-center"><a class="btn btn-xs btn-info button">${result['Status']}</a>${workpage}</td>
+                                <td class="status text-center"><a class="btn btn-xs btn-info button">${result['Status']}</a></td>
                             %else:
                                 %if result['Status'] == 'Have':
-                                    <td class="status text-center"><a class="btn btn-xs btn-info button">${result['Status']}</a>${workpage}</td>
+                                    <td class="status text-center"><a class="btn btn-xs btn-info button">${result['Status']}</a></td>
                                 %else:
-                                    <td class="status text-center"><a class="btn btn-xs btn-default button">${result['Status']}</a>${workpage}</td>
+                                    <td class="status text-center"><a class="btn btn-xs btn-default button">${result['Status']}</a></td>
                                 %endif:
                             %endif
                         %endif
@@ -194,7 +200,7 @@
 </%def>
 
 <%def name="headIncludes()">
-    
+
     %if author['Status'] == 'Loading':
     <meta http-equiv="refresh" content="12">
     <script type="text/javascript">
@@ -205,14 +211,14 @@
     %endif
 </%def>
 
-<%def name="javascriptIncludes()">    
+<%def name="javascriptIncludes()">
 <script type="text/javascript">
     $(document).ready(function()
     {
         var oTable = $('#book_table').dataTable(
             {
                 "order": [],
-                "columnDefs": 
+                "columnDefs":
                     [{ targets: 'no-sort', orderable: false }] // Don't allow colums of class no-sort to be sorted
                 ,
                 "oLanguage": {
@@ -227,19 +233,18 @@
                 "iDisplayLength": 10,
                 "fnRowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
                     var w = window.innerWidth;
-                    if ( w < 768 ) 
+                    if ( w < 768 )
                     {   // hide cover,seriesnum,stars,date on small devices
                         $('td', nRow).eq(1).addClass('hidden');
                         $('td', nRow).eq(4).addClass('hidden');
                         $('td', nRow).eq(5).addClass('hidden');
                         $('td', nRow).eq(6).addClass('hidden');
-                    }                                    
+                    }
                     return nRow;
-                },          
+                },
             });
 			$('.dataTables_filter input').attr("placeholder", "Search filter");
 			$(window).resize(function() {oTable.fnDraw(false)});
     });
 </script>
 </%def>
-

--- a/data/interfaces/bookstrap/author.html
+++ b/data/interfaces/bookstrap/author.html
@@ -146,23 +146,23 @@
                         starimg = '0-stars.png'
 
                     if 'goodreads' in result['booklink']:
-                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoodReads</i></a>'
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><small><i>GoodReads</i></small></a>'
                     if 'google' in result['booklink']:
-                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoogleBooks</i></a>'
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><small><i>GoogleBooks</i></small></a>'
 
                     workpage = ''
                     if result['workpage']:
                         if len(result['workpage']) > 4:
-                            workpage = '<a href="' + result['workpage'] + '" target="_new"><i class="smalltext">LibraryThing</i></a>'
+                            workpage = '<a href="' + result['workpage'] + '" target="_new"><small><i>LibraryThing</i></small></a>'
                 %>
                 <tr>
                     <td class="select"><input type="checkbox" name="${result['BookID']}" /></td>
                     <td class="bookart text-center"><a href="${result['bookimg']}" target="_blank" rel="noreferrer"><img src="${result['bookimg']}" class="bookcover-xs img-responsive" alt="Cover"></a></td>
                     %if result['booksub']:
                         <td class id="bookname">${result['bookname']}<br>
-                        <i class="smalltext">${result['booksub']}</i><br>${workpage}&nbsp;${sitelink}</td>
+                        <small><i>${result['booksub']}</i></small><br>${sitelink}&nbsp;${workpage}</td>
                     %else:
-                        <td class="bookname">${result['bookname']}<br>${workpage}&nbsp;${sitelink}</td>
+                        <td class="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}</td>
                     %endif
                     <td class="series">${result['Series']}</td>
                     <td class="seriesNum text-center">${result['seriesNum']}</td>

--- a/data/interfaces/bookstrap/author.html
+++ b/data/interfaces/bookstrap/author.html
@@ -154,15 +154,16 @@
                     if result['workpage']:
                         if len(result['workpage']) > 4:
                             workpage = '<a href="' + result['workpage'] + '" target="_new"><small><i>LibraryThing</i></small></a>'
+                    editpage = '<a href="editBook?bookid=' + result['bookID'] + '" target="_new"><small><i>Edit</i></a>'
                 %>
                 <tr>
                     <td class="select"><input type="checkbox" name="${result['BookID']}" /></td>
                     <td class="bookart text-center"><a href="${result['bookimg']}" target="_blank" rel="noreferrer"><img src="${result['bookimg']}" class="bookcover-xs img-responsive" alt="Cover"></a></td>
                     %if result['booksub']:
                         <td class id="bookname">${result['bookname']}<br>
-                        <small><i>${result['booksub']}</i></small><br>${sitelink}&nbsp;${workpage}</td>
+                        <small><i>${result['booksub']}</i></small><br>${sitelink}&nbsp;${workpage}&nbsp;${editpage}</td>
                     %else:
-                        <td class="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}</td>
+                        <td class="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}&nbsp;${editpage}</td>
                     %endif
                     <td class="series">${result['Series']}</td>
                     <td class="seriesNum text-center">${result['seriesNum']}</td>

--- a/data/interfaces/bookstrap/books.html
+++ b/data/interfaces/bookstrap/books.html
@@ -24,7 +24,7 @@
             %endif
             </div>
         </form>
-    </div>    
+    </div>
 </%def>
 
 <%def name="body()">
@@ -37,7 +37,7 @@
                 <option value="Wanted">Wanted</option>
                 <option value="Have">Have</option>
                 <option value="Remove">Remove</option>
-            </select>                
+            </select>
         </div>
         <input type="submit" class="markBooks btn btn-sm btn-primary" value="Go">
 
@@ -64,16 +64,16 @@
 </%def>
 
 <%def name="headIncludes()">
-    
+
 </%def>
 
-<%def name="javascriptIncludes()">    
+<%def name="javascriptIncludes()">
     <script type="text/javascript">
     $(document).ready(function() {
         var oTable = $('#book_table').dataTable({
             "bAutoWidth": false,
             "order": [[ 2, 'asc' ]],
-            "columnDefs": 
+            "columnDefs":
                 [{ targets: 'no-sort', orderable: false }]
             ,
             "oLanguage": {
@@ -92,22 +92,22 @@
             "bFilter": true,
             "fnRowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
                 var w = window.innerWidth;
-                if ( w < 768 ) 
+                if ( w < 768 )
                 {   // hide cover,seriesnum,stars,date on small devices
                     $('td', nRow).eq(1).addClass('hidden');
                     $('td', nRow).eq(5).addClass('hidden');
                     $('td', nRow).eq(6).addClass('hidden');
                     $('td', nRow).eq(7).addClass('hidden');
-                }                                    
+                }
                 return nRow;
-            },          
+            },
         });
         $('.dataTables_filter input').attr("placeholder", "Search filter");
     	$(window).resize(function() {oTable.fnDraw(false)});
-        
+
         $('#chooselanguage').val(getUrlVars()['BookLang']);
     });
-    
+
     // Read a page's GET URL variables and return them as an associative array.
 	function getUrlVars() {
         var vars = [], hash;
@@ -118,6 +118,6 @@
             vars[hash[0]] = hash[1];
         }
         return vars;
-    }        
+    }
     </script>
 </%def>

--- a/data/interfaces/bookstrap/editbook.html
+++ b/data/interfaces/bookstrap/editbook.html
@@ -1,0 +1,90 @@
+<%inherit file="base.html"/>
+<%!
+    import lazylibrarian
+%>
+
+<%def name="headerIncludes()">
+    <div id="subhead_container">
+        <div id="subhead_menu">
+        </div>
+    </div>
+</%def>
+<%def name="body()">
+    <form action="bookUpdate" method="post">
+        <div class="configtable">
+        <fieldset>
+            <legend>${config['authorName']}</legend>
+            <div class="form-group">
+                <label for="moveBook" class="control-label">Change author to: </label>
+                <select id="moveBook" class="moveBook form-control input-sm" name="authorname">
+                %for item in authors:
+                    <option value="${item['AuthorName']}"
+                    %if config['authorName'] == item['AuthorName']:
+                        selected = "selected"
+                    %endif
+                    >${item['AuthorName']}</option>
+                %endfor
+                </select>
+            </div>
+
+            <div class="form-group">
+                <input type="text" id="bookid" name="bookid" value="${config['bookID']}" class="hidden">
+            </div>
+            <div class="form-group">
+                <label for="bookname" class="control-label">Book Title:</label>
+                <input type="text" id="bookname" name="bookname" value="${config['bookName']}" class="form-control" placeholder="Book Title">
+            </div>
+            <div class="form-group">
+                <label for="booksub" class="control-label">Subtitle:</label>
+                <input type="text" id="booksub" name="booksub" value="${config['bookSub']}" class="form-control" placeholder="Subtitle">
+            </div>
+            <div class="form-group">
+                <label for="bookgenre" class="control-label">Genre:</label>
+                <input type="text" id="bookgenre" name="bookgenre" value="${config['bookGenre']}" class="form-control" placeholder="Genre">
+            </div>
+            <div class="form-group">
+                <label for="series" class="control-label">Series:</label>
+                <input type="text" id="series" name="series" value="${config['Series']}" class="form-control" placeholder="Series">
+            </div>
+            <div class="form-group">
+                <label for="seriesnum" class="control-label">Series Number:</label>
+                <input type="text" id="seriesnum" name="seriesnum" value="${config['SeriesNum']}" class="form-control" placeholder="Series Number">
+            </div>
+            <div class="checkbox">
+                <%
+                    if config['Manual'] == "1":
+                        checked = 'checked="checked"'
+                    else:
+                        checked = ''
+                %>
+                <label for="manual" class="control-label">
+                <input type="checkbox" id="manual" name="manual" value="1" ${checked} />
+                Lock settings</label>
+            </div>
+
+        </fieldset>
+
+        <div class="table_wrapper_button">
+            <input type="submit" value="Save changes" id="add" class="btn btn-primary">
+        </div>
+
+    </div> <!-- form -->
+
+    </form>
+
+
+</%def>
+
+<%def name="javascriptIncludes()">
+    <script type="text/javascript">
+        function initThisPage()
+
+        {
+            "use strict";
+        }
+        $(document).ready(function() {
+            initThisPage();
+        });
+    </script>
+</%def>
+<html><head></head><body></body></html>

--- a/data/interfaces/bookstrap/searchresults.html
+++ b/data/interfaces/bookstrap/searchresults.html
@@ -6,7 +6,7 @@
 <%def name="body()">
 
 <h1>Search Results</h1>
-    
+
 <div class="table-responsive">
     <table class="display table table-striped table-hover table-bordered" id="book_table">
         <thead>
@@ -106,7 +106,7 @@
 </%def>
 
 <%def name="headIncludes()">
-    
+
 </%def>
 
 <%def name="javascriptIncludes()">
@@ -126,7 +126,7 @@
                     null,
                     null
                     ],
-                "columnDefs": 
+                "columnDefs":
                     [{ targets: 'no-sort', orderable: false }]
                 ,
                 "oLanguage": {
@@ -138,7 +138,7 @@
                 "iDisplayLength": 10,
                 "sPaginationType": "full_numbers",
             });
-			$('.dataTables_filter input').attr("placeholder", "Seach table here");
+			$('.dataTables_filter input').attr("placeholder", "Search table here");
     });
     </script>
 </%def>

--- a/data/interfaces/default/author.html
+++ b/data/interfaces/default/author.html
@@ -3,7 +3,7 @@
 <%def name="headerIncludes()">
     <div id="subhead_container">
         <ul id="subhead_menu">
-            
+
             <li><a href="refreshAuthor?AuthorID=${author['AuthorID']}" id="button"> Refresh Author </a></li>
             <li><a href="deleteAuthor?AuthorID=${author['AuthorID']}" id="button"> Delete Author </a></li>
             %if author['Status'] == 'Paused':
@@ -14,7 +14,7 @@
             <li><a href="authorPage?AuthorID=${author['AuthorID']}&Ignored=True" id="button"> Ignored Books </a></li>
             %if len(languages) >= 1:
                 <li>Language:&nbsp</li>
-                
+
                 <li><select onchange="window.location = 'authorPage?AuthorID=${author['AuthorID']}&BookLang=' + this.options[this.selectedIndex].value">
                     <option>Select</option>
                 %for language in languages:
@@ -100,8 +100,8 @@
                 <th id="select"><input type="checkbox" onClick="toggleAll(this)" /></th>
                 <th id="bookart">Cover</th>
                 <th id="bookname">Title</th>
-		<th id="series">Series</th>
-		<th id="seriesNum">Num.</th>
+		        <th id="series">Series</th>
+		        <th id="seriesNum">Num.</th>
                 <th id="stars">Rating</th>
                 <th id="date">Released</th>
                 <th id="language">Language</th>
@@ -126,19 +126,25 @@
                         starimg = '5-stars.png'
                     else:
                         starimg = '0-stars.png'
+
+                    if 'goodreads' in result['booklink']:
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoodReads</i></a>'
+                    if 'google' in result['booklink']:
+                        sitelink = '<a href="' + result['booklink'] + '" target="_new"><i class="smalltext">GoogleBooks</i></a>'
+
                     workpage = ''
                     if result['workpage']:
                         if len(result['workpage']) > 4:
-                            workpage = '<br><a href="' + result['workpage'] + '" target="_new">WorkPage</a>' 
+                            workpage = '<a href="' + result['workpage'] + '" target="_new"><i class="smalltext">LibraryThing</i></a>'
                 %>
                 <tr class="gradeZ">
                     <td id="select"><input type="checkbox" name="${result['BookID']}" class="checkbox" /></td>
                     <td id="bookart"><a href="${result['bookimg']}" target="_new"><img src="${result['bookimg']}" height="75" width="50"></a></td>
                     %if result['booksub']:
-                        <td id="bookname"><a href="${result['booklink']}" target="_new">${result['bookname']}</a><br>
-                        <i class="smalltext">${result['booksub']}</i></td>
+                        <td id="bookname">${result['bookname']}<br>
+                        <i class="smalltext">${result['booksub']}</i><br>${workpage}&nbsp;${sitelink}</td>
                     %else:
-                        <td id="bookname"><a href="${result['booklink']}" target="_new">${result['bookname']}</a></td>
+                        <td id="bookname">${result['bookname']}<br>${workpage}&nbsp;${sitelink}</td>
                     %endif
                     <td id="series">${result['Series']}</td>
                     <td id="seriesNum">${result['seriesNum']}</td>
@@ -150,12 +156,12 @@
                         <td id="status"><a class="button green" href="openBook?bookid=${result['bookID']}" target="_self">${result['Status']}</a>${workpage}</td>
                     %else:
                         %if result['Status'] == 'Wanted':
-                            <td id="status"><a class="button red" href="searchForBook?bookid=${result['bookID']}" target="_self"><span class="a">${result['Status']}</span><span class="b">Search</span></a>${workpage}</td>
+                            <td id="status"><a class="button red" href="searchForBook?bookid=${result['bookID']}" target="_self"><span class="a">${result['Status']}</span><span class="b">Search</span></a></td>
                         %else:
                             %if result['Status'] == 'Snatched':
-                                <td id="status"><a class="button">${result['Status']}</a>${workpage}</td>
+                                <td id="status"><a class="button">${result['Status']}</a></td>
                             %else:
-                                <td id="status"><a class="button grey">${result['Status']}</a>${workpage}</td>
+                                <td id="status"><a class="button grey">${result['Status']}</a></td>
                             %endif
                         %endif
                     %endif
@@ -182,7 +188,7 @@
 <%def name="javascriptIncludes()">
     <script src="js/libs/jquery.dataTables.min.js"></script>
     <script>
-        
+
     $(document).ready(function()
     {
         var oTable = $('#book_table').dataTable(
@@ -199,40 +205,39 @@
                 "iDisplayLength": 10,
                 "fnRowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
                     var w = window.innerWidth;
-                    if ( w < 320 ) 
+                    if ( w < 320 )
                     {   // hide cover,series,seriesnum,stars,date on smallest devices
                         $('td', nRow).eq(1).addClass('hidden');
                         $('td', nRow).eq(3).addClass('hidden');
                         $('td', nRow).eq(4).addClass('hidden');
                         $('td', nRow).eq(5).addClass('hidden');
                         $('td', nRow).eq(6).addClass('hidden');
-                    }                                    
-                    if ( w < 640 ) 
+                    }
+                    if ( w < 640 )
                     {   // hide cover,series,seriesnum,stars,date on smaller devices
                         $('td', nRow).eq(1).addClass('hidden');
                         $('td', nRow).eq(3).addClass('hidden');
                         $('td', nRow).eq(4).addClass('hidden');
                         $('td', nRow).eq(5).addClass('hidden');
                         $('td', nRow).eq(6).addClass('hidden');
-                    }                                    
-                    if ( w < 768 ) 
+                    }
+                    if ( w < 768 )
                     {   // hide cover,seriesnum,stars,date on small devices
                         $('td', nRow).eq(1).addClass('hidden');
                         $('td', nRow).eq(4).addClass('hidden');
                         $('td', nRow).eq(5).addClass('hidden');
                         $('td', nRow).eq(6).addClass('hidden');
-                    }                                    
-                    if ( w < 1024 ) 
+                    }
+                    if ( w < 1024 )
                     {   // hide stars,date on medium devices
                         $('td', nRow).eq(5).addClass('hidden');
                         $('td', nRow).eq(6).addClass('hidden');
-                    }                                    
+                    }
                     return nRow;
-                },          
+                },
             });
 			$('.dataTables_filter input').attr("placeholder", "Search table here");
             $(window).resize(function() {oTable.fnDraw(false)});
     });
     </script>
 </%def>
-

--- a/data/interfaces/default/author.html
+++ b/data/interfaces/default/author.html
@@ -136,15 +136,16 @@
                     if result['workpage']:
                         if len(result['workpage']) > 4:
                             workpage = '<a href="' + result['workpage'] + '" target="_new"><i class="smalltext">LibraryThing</i></a>'
+                    editpage = '<a href="editBook?bookid=' + result['bookID'] + '"><i class="smalltext">Edit</i></a>'
                 %>
                 <tr class="gradeZ">
                     <td id="select"><input type="checkbox" name="${result['BookID']}" class="checkbox" /></td>
                     <td id="bookart"><a href="${result['bookimg']}" target="_new"><img src="${result['bookimg']}" height="75" width="50"></a></td>
                     %if result['booksub']:
                         <td id="bookname">${result['bookname']}<br>
-                        <i class="smalltext">${result['booksub']}</i><br>${sitelink}&nbsp;${workpage}</td>
+                        <i class="smalltext">${result['booksub']}</i><br>${sitelink}&nbsp;${workpage}&nbsp;${editpage}</td>
                     %else:
-                        <td id="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}</td>
+                        <td id="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}&nbsp;${editpage}</td>
                     %endif
                     <td id="series">${result['Series']}</td>
                     <td id="seriesNum">${result['seriesNum']}</td>

--- a/data/interfaces/default/author.html
+++ b/data/interfaces/default/author.html
@@ -142,9 +142,9 @@
                     <td id="bookart"><a href="${result['bookimg']}" target="_new"><img src="${result['bookimg']}" height="75" width="50"></a></td>
                     %if result['booksub']:
                         <td id="bookname">${result['bookname']}<br>
-                        <i class="smalltext">${result['booksub']}</i><br>${workpage}&nbsp;${sitelink}</td>
+                        <i class="smalltext">${result['booksub']}</i><br>${sitelink}&nbsp;${workpage}</td>
                     %else:
-                        <td id="bookname">${result['bookname']}<br>${workpage}&nbsp;${sitelink}</td>
+                        <td id="bookname">${result['bookname']}<br>${sitelink}&nbsp;${workpage}</td>
                     %endif
                     <td id="series">${result['Series']}</td>
                     <td id="seriesNum">${result['seriesNum']}</td>

--- a/data/interfaces/default/books.html
+++ b/data/interfaces/default/books.html
@@ -38,8 +38,8 @@
                 <th id="bookart">Cover</th>
                 <th id="authorname">Author</th>
                 <th id="bookname">Title</th>
-		<th id="series">Series</th>
-		<th id="seriesNum">Num</th>
+		        <th id="series">Series</th>
+		        <th id="seriesNum">Num</th>
                 <th id="stars">Rating</th>
                 <th id="date">Released</th>
                 <th id="status">Status</th>

--- a/data/interfaces/default/editbook.html
+++ b/data/interfaces/default/editbook.html
@@ -1,0 +1,90 @@
+<%inherit file="base.html"/>
+<%!
+    import lazylibrarian
+%>
+
+<%def name="headerIncludes()">
+    <div id="subhead_container">
+    </div>
+</%def>
+<%def name="body()">
+<BR><br>
+<h1>&nbsp&nbsp${config['authorName']}</h1>
+<br><br>
+    <form action="bookUpdate" method="post">
+    <div class="table_wrapper">
+        <table class="configtable">
+            <tr>
+            <td>
+            <div>
+                <input type="text" name="bookid" value="${config['bookID']}" class="hidden">
+            </div>
+            <div class="row">
+                <label>Change author to: </label>
+                <select class="form-control" name="authorname" size="36">
+                %for item in authors:
+                    <option value="${item['AuthorName']}"
+                    %if config['authorName'] == item['AuthorName']:
+                        selected = "selected"
+                    %endif
+                    >${item['AuthorName']}</option>
+                %endfor
+                </select>
+            </div>
+
+            <div class="row">
+                <label>Book Title:</label>
+                <input type="text" name="bookname" value="${config['bookName']}" class="form-control" placeholder="Book Title" size="36">
+                <br><br>
+            </div>
+            <div class="row">
+                <label>Subtitle:</label>
+                <input type="text" name="booksub" value="${config['bookSub']}" class="form-control" placeholder="Subtitle" size="36">
+                <br><br>
+            </div>
+            <div class="row">
+                <label>Genre:</label>
+                <input type="text" name="bookgenre" value="${config['bookGenre']}" class="form-control" placeholder="Genre" size="36">
+                <br><br>
+            </div>
+            <div class="row">
+                <label>Series:</label>
+                <input type="text" id="series" name="series" value="${config['Series']}" class="form-control" size="36" placeholder="Series">
+                <br><br>
+            </div>
+            <div class="row">
+                <label>Series Number:</label>
+                <input type="text" name="seriesnum" value="${config['SeriesNum']}" placeholder="Series Number" size="36">
+                <br><br>
+            </div>
+            <%
+                if config['Manual'] == "1":
+                    checked = 'checked="checked"'
+                else:
+                    checked = ''
+            %>
+            <BR>
+            <input type="checkbox" id="manual" name="manual" value=1 ${checked} />
+            <label>  Lock settings</label>
+            </td></tr></table>
+        </div>
+
+    <div class="table_wrapper_button">
+        <p><input type="submit" value="Save changes" id="add"></p>
+    </div>
+
+</form>
+</%def>
+
+<%def name="javascriptIncludes()">
+    <script>
+        function initThisPage()
+        {
+
+        }
+
+        $(document).ready(function() {
+            initThisPage();
+        });
+    </script>
+</%def>

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -56,7 +56,7 @@
                 <td id="date">${author['LastDate']}</td>
                 <td id="have"><span title="${percent}"></span>${css}
 				<div style="width:${percent}%"><span class="progressbar-front-text">${havebooks}/${totalbooks}</span></div></td>
-				
+
                 <td id="status">${author['Status']}</td>
             </tr>
         %endfor
@@ -94,7 +94,7 @@
                 "sPaginationType": "full_numbers",
                 "aaSorting": [[0, 'asc']],
             });
-			$('.dataTables_filter input').attr("placeholder", "Seach table here");
+			$('.dataTables_filter input').attr("placeholder", "Search table here");
     });
     </script>
 </%def>

--- a/data/interfaces/default/issues.html
+++ b/data/interfaces/default/issues.html
@@ -61,7 +61,7 @@
 <%def name="javascriptIncludes()">
     <script src="js/libs/jquery.dataTables.min.js"></script>
     <script>
-        
+
     $(document).ready(function()
     {
 
@@ -84,7 +84,7 @@
                 "aLengthMenu": [[5, 10, 15, 25, 50, 100, -1], [5, 10, 15, 25, 50, 100, "All"]],
                 "iDisplayLength": 10,
             });
-            $('.dataTables_filter input').attr("placeholder", "Seach table here");
+            $('.dataTables_filter input').attr("placeholder", "Search table here");
     });
     </script>
 </%def>

--- a/data/interfaces/default/magazines.html
+++ b/data/interfaces/default/magazines.html
@@ -118,7 +118,7 @@
                 "aLengthMenu": [[5, 10, 15, 25, 50, 100, -1], [5, 10, 15, 25, 50, 100, "All"]],
                 "iDisplayLength": 10,
             });
-            $('.dataTables_filter input').attr("placeholder", "Seach table here");
+            $('.dataTables_filter input').attr("placeholder", "Search table here");
     });
     </script>
 </%def>

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -127,7 +127,7 @@
                 "iDisplayLength": 10,
                 "sPaginationType": "full_numbers",
             });
-			$('.dataTables_filter input').attr("placeholder", "Seach table here");
+			$('.dataTables_filter input').attr("placeholder", "Search table here");
     });
     </script>
 </%def>

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -1325,7 +1325,8 @@ def dbcheck():
     # 3 removed SeriesOrder column from books table as redundant
     # 4 added duplicates column to stats table
     # 5 issue numbers padded to 4 digits with leading zeros
-    db_current_version = 5
+    # 6 added Manual field to books table for user editing
+    db_current_version = 6
 
     if db_version < db_current_version:
         logger.info('Updating database to version %s, current version is %s' % (db_current_version, db_version))
@@ -1339,7 +1340,7 @@ def dbcheck():
                 BookName TEXT, BookSub TEXT, BookDesc TEXT, BookGenre TEXT, BookIsbn TEXT, BookPub TEXT, \
                 BookRate INTEGER, BookImg TEXT, BookPages INTEGER, BookLink TEXT, BookID TEXT UNIQUE, BookFile TEXT, \
                 BookDate TEXT, BookLang TEXT, BookAdded TEXT, Status TEXT, Series TEXT, SeriesNum TEXT, \
-                WorkPage TEXT)')
+                WorkPage TEXT, Manual TEXT)')
             c.execute('CREATE TABLE IF NOT EXISTS wanted (BookID TEXT, NZBurl TEXT, NZBtitle TEXT, NZBdate TEXT, \
                 NZBprov TEXT, Status TEXT, NZBsize TEXT, AuxInfo TEXT, NZBmode TEXT)')
             c.execute('CREATE TABLE IF NOT EXISTS pastissues AS SELECT * FROM wanted')  # same columns
@@ -1553,6 +1554,14 @@ def dbcheck():
                     issuedate = str(mag['IssueDate'])
                     issuedate = issuedate.zfill(4)
                     myDB.action('UPDATE magazines SET IssueDate="%s" WHERE Title="%s"' % (issuedate, title))
+
+        if db_version < 6:
+            try:
+                c.execute('SELECT Manual from bookss')
+            except sqlite3.OperationalError:
+                logger.info('Updating books table to hold Manual')
+                c.execute('ALTER TABLE books ADD COLUMN Manual TEXT')
+
 
 
         c.execute('PRAGMA user_version = %s' % db_current_version)

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -1557,12 +1557,10 @@ def dbcheck():
 
         if db_version < 6:
             try:
-                c.execute('SELECT Manual from bookss')
+                c.execute('SELECT Manual from books')
             except sqlite3.OperationalError:
                 logger.info('Updating books table to hold Manual')
                 c.execute('ALTER TABLE books ADD COLUMN Manual TEXT')
-
-
 
         c.execute('PRAGMA user_version = %s' % db_current_version)
         conn.commit()

--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -499,6 +499,15 @@ class GoogleBooks:
                                     rejected = True
                                     duplicates = duplicates + 1
                                     break
+                    if not rejected:
+                        find_books = myDB.select('SELECT * FROM books WHERE BookID = "%s"' % bookid)
+                        if find_books:
+                            # we have a book with this bookid already
+                            logger.debug('Rejecting bookid %s for [%s][%s] already got bookid' %
+                                (bookid, authorNameResult, bookname))
+                            duplicates = duplicates + 1
+                            rejected = True
+                            break
 
                     if not rejected:
                         if book_status != "Ignored" and not locked:

--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -470,8 +470,10 @@ class GoogleBooks:
                     if find_book_status:
                         for resulted in find_book_status:
                             book_status = resulted['Status']
+                            locked = resulted['Manual']
                     else:
                         book_status = lazylibrarian.NEWBOOK_STATUS
+                        locked = False
 
                     rejected = False
                     if re.match('[^\w-]', bookname):  # remove books with bad characters in title
@@ -499,7 +501,7 @@ class GoogleBooks:
                                     break
 
                     if not rejected:
-                        if book_status != "Ignored":
+                        if book_status != "Ignored" and not locked:
                             controlValueDict = {"BookID": bookid}
                             newValueDict = {
                                 "AuthorName": authorname,

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -469,34 +469,45 @@ class GoodReads:
                                     break
 
                     if not rejected:
-                        if book_status != "Ignored" and not locked:
-                            controlValueDict = {"BookID": bookid}
-                            newValueDict = {
-                                "AuthorName": authorNameResult,
-                                "AuthorID": authorid,
-                                "AuthorLink": None,
-                                "BookName": bookname,
-                                "BookSub": booksub,
-                                "BookDesc": bookdesc,
-                                "BookIsbn": bookisbn,
-                                "BookPub": bookpub,
-                                "BookGenre": None,
-                                "BookImg": bookimg,
-                                "BookLink": booklink,
-                                "BookRate": bookrate,
-                                "BookPages": bookpages,
-                                "BookDate": pubyear,
-                                "BookLang": bookLanguage,
-                                "Status": book_status,
-                                "BookAdded": today(),
-                                "Series": series,
-                                "SeriesNum": seriesNum
-                            }
+                        find_books = myDB.select('SELECT * FROM books WHERE BookID = "%s"' % bookid)
+                        if find_books:
+                            # we have a book with this bookid already
+                            logger.debug('Rejecting bookid %s for [%s][%s] already got bookid' %
+                                (bookid, authorNameResult, bookname))
+                            duplicates = duplicates + 1
+                            rejected = True
+                            break
 
-                            resultsCount = resultsCount + 1
+                    if not rejected:
+                        if book_status != "Ignored":
+                            if not locked:
+                                controlValueDict = {"BookID": bookid}
+                                newValueDict = {
+                                    "AuthorName": authorNameResult,
+                                    "AuthorID": authorid,
+                                    "AuthorLink": None,
+                                    "BookName": bookname,
+                                    "BookSub": booksub,
+                                    "BookDesc": bookdesc,
+                                    "BookIsbn": bookisbn,
+                                    "BookPub": bookpub,
+                                    "BookGenre": None,
+                                    "BookImg": bookimg,
+                                    "BookLink": booklink,
+                                    "BookRate": bookrate,
+                                    "BookPages": bookpages,
+                                    "BookDate": pubyear,
+                                    "BookLang": bookLanguage,
+                                    "Status": book_status,
+                                    "BookAdded": today(),
+                                    "Series": series,
+                                    "SeriesNum": seriesNum
+                                }
 
-                            myDB.upsert("books", newValueDict, controlValueDict)
-                            logger.debug(u"Book found: " + book.find('title').text + " " + pubyear)
+                                resultsCount = resultsCount + 1
+
+                                myDB.upsert("books", newValueDict, controlValueDict)
+                                logger.debug(u"Book found: " + book.find('title').text + " " + pubyear)
 
                             if 'nocover' in bookimg or 'nophoto' in bookimg:
                                 # try to get a cover from librarything

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -437,8 +437,10 @@ class GoodReads:
                     if find_book_status:
                         for resulted in find_book_status:
                             book_status = resulted['Status']
+                            locked = resulted ['Manual']
                     else:
                         book_status = lazylibrarian.NEWBOOK_STATUS
+                        locked = False
 
                     rejected = False
 
@@ -467,7 +469,7 @@ class GoodReads:
                                     break
 
                     if not rejected:
-                        if book_status != "Ignored":
+                        if book_status != "Ignored" and not locked:
                             controlValueDict = {"BookID": bookid}
                             newValueDict = {
                                 "AuthorName": authorNameResult,

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -405,7 +405,6 @@ class GoodReads:
                             logger.debug('Skipped a book with language %s' % bookLanguage)
                             ignored = ignored + 1
                             continue
-
                     bookname = book.find('title').text
                     bookid = book.find('id').text
                     bookdesc = book.find('description').text
@@ -414,12 +413,22 @@ class GoodReads:
                     booklink = book.find('link').text
                     bookrate = float(book.find('average_rating').text)
                     bookpages = book.find('num_pages').text
-
                     bookname = unaccented(bookname)
+                    if ': ' in bookname:
+                        parts = bookname.split(': ', 1)
+                        bookname = parts[0]
+                        booksub = parts[1]
+                    else:
+                        booksub = ''
                     dic = {':': '', '"': '', '\'': ''}
                     bookname = replace_all(bookname, dic)
                     bookname = bookname.strip()  # strip whitespace
-                    series,seriesNum = bookSeries(bookname)
+                    booksub = replace_all(booksub, dic)
+                    booksub = booksub.strip()  # strip whitespace
+                    if booksub:
+                        series,seriesNum = bookSeries(booksub)
+                    else:
+                        series,seriesNum = bookSeries(bookname)
 
                     # GoodReads sometimes has multiple bookids for the same book (same author/title, different editions)
                     # and sometimes uses the same bookid if the book is the same but the title is slightly different
@@ -465,7 +474,7 @@ class GoodReads:
                                 "AuthorID": authorid,
                                 "AuthorLink": None,
                                 "BookName": bookname,
-                                "BookSub": None,
+                                "BookSub": booksub,
                                 "BookDesc": bookdesc,
                                 "BookIsbn": bookisbn,
                                 "BookPub": bookpub,
@@ -645,21 +654,24 @@ class GoodReads:
         if author:
             AuthorID = author['authorid']
 
-        result = re.search(r"\(([\S\s]+),? #(\d+\.?-?\d{0,})", bookname)
-        if result:
-            series = result.group(1)
-            if series[-1] == ',':
-                series = series[:-1]
-            seriesNum = result.group(2)
-        else:
-            series = None
-            seriesNum = None
-
         dic = {':': '', '"': '', '\'': ''}
         bookname = replace_all(bookname, dic)
 
         bookname = unaccented(bookname)
+        if ': ' in bookname:
+            parts = bookname.split(': ', 1)
+            bookname = parts[0]
+            booksub = parts[1]
+
+        dic = {':': '', '"': '', '\'': ''}
+        bookname = replace_all(bookname, dic)
         bookname = bookname.strip()  # strip whitespace
+        booksub = replace_all(booksub, dic)
+        booksub = booksub.strip()  # strip whitespace
+        if booksub:
+           series,seriesNum = bookSeries(booksub)
+        else:
+           series,seriesNum = bookSeries(bookname)
 
         controlValueDict = {"BookID": bookid}
         newValueDict = {
@@ -667,7 +679,7 @@ class GoodReads:
             "AuthorID": AuthorID,
             "AuthorLink": None,
             "BookName": bookname,
-            "BookSub": None,
+            "BookSub": booksub,
             "BookDesc": bookdesc,
             "BookIsbn": bookisbn,
             "BookPub": bookpub,

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -131,8 +131,9 @@ def find_book_in_db(myDB, author, book):
         # These are results that work well on my library, minimal false matches and no misses
         # on books that should be matched
         # Maybe make ratios configurable in config.ini later
-
+        print "**", repr(author)
         books = myDB.select('SELECT BookID,BookName FROM books where AuthorName="%s"' % author)
+
         best_ratio = 0
         best_partial = 0
         ratio_name = ""

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -198,11 +198,13 @@ def processResultList(resultlist, book, searchtype):
         logger.info(u'Best match NZB (%s%%): %s using %s search' %
             (score, nzb_Title, searchtype))
 
-        myDB.upsert("wanted", newValueDict, controlValueDict)
-
         snatchedbooks = myDB.action('SELECT * from books WHERE BookID="%s" and Status="Snatched"' %
                                     newValueDict["BookID"]).fetchone()
-        if not snatchedbooks:
+        if snatchedbooks:
+            logger.debug('%s already marked snatched' % nzb_Title)
+            return False
+        else:
+            myDB.upsert("wanted", newValueDict, controlValueDict)
             if nzbmode == "torznab":
                 snatch = TORDownloadMethod(newValueDict["BookID"], newValueDict["NZBprov"],
                                            newValueDict["NZBtitle"], controlValueDict["NZBurl"])
@@ -213,8 +215,8 @@ def processResultList(resultlist, book, searchtype):
                 notifiers.notify_snatch(newValueDict["NZBtitle"] + ' at ' + now())
                 scheduleJob(action='Start', target='processDir')
                 return True
-
-    logger.debug("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() +
+    else:
+        logger.debug("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() +
                  " using searchtype " + searchtype)
     return False
 

--- a/lazylibrarian/searchnzb.py
+++ b/lazylibrarian/searchnzb.py
@@ -100,8 +100,8 @@ def search_nzb_book(books=None, reset=False):
 
         if not found:
             logger.debug("NZB Searches for %s returned no results." % book['searchterm'])
-        else:
-            nzb_count = nzb_count + 1
+        if found > True:
+            nzb_count = nzb_count + 1  # we found it
 
     logger.info("NZBSearch for Wanted items complete, found %s book%s" % (nzb_count, plural(nzb_count)))
 
@@ -202,7 +202,7 @@ def processResultList(resultlist, book, searchtype):
                                     newValueDict["BookID"]).fetchone()
         if snatchedbooks:
             logger.debug('%s already marked snatched' % nzb_Title)
-            return False
+            return True  # someone else found it
         else:
             myDB.upsert("wanted", newValueDict, controlValueDict)
             if nzbmode == "torznab":
@@ -214,7 +214,7 @@ def processResultList(resultlist, book, searchtype):
             if snatch:
                 notifiers.notify_snatch(newValueDict["NZBtitle"] + ' at ' + now())
                 scheduleJob(action='Start', target='processDir')
-                return True
+                return True + True  # we found it
     else:
         logger.debug("No nzb's found for " + (book["authorName"] + ' ' + book['bookName']).strip() +
                  " using searchtype " + searchtype)

--- a/lazylibrarian/searchrss.py
+++ b/lazylibrarian/searchrss.py
@@ -80,7 +80,7 @@ def search_rss_book(books=None, reset=False):
 
         if not found:
             logger.debug("Searches returned no results. Adding book %s - %s to queue." % (author, title))
-        else:
+        if found > True:
             rss_count = rss_count + 1
 
     logger.info("RSS Search for Wanted items complete, found %s book%s" % (rss_count, plural(rss_count)))
@@ -180,7 +180,7 @@ def processResultList(resultlist, author, title, book):
 
         if snatchedbooks:  # check if one of the other downloaders got there first
             logger.debug('%s already marked snatched' % nzb_Title)
-            return False
+            return True
         else:
             myDB.upsert("wanted", newValueDict, controlValueDict)
             tor_url = controlValueDict["NZBurl"]
@@ -202,7 +202,7 @@ def processResultList(resultlist, author, title, book):
             if snatch:
                 notify_snatch(newValueDict["NZBtitle"] + ' at ' + now())
                 scheduleJob(action='Start', target='processDir')
-                return True
+                return True + True  # we found it
     else:
         logger.debug("No RSS found for " + (book["authorName"] + ' ' +
                 book['bookName']).strip())

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -105,7 +105,7 @@ def search_tor_book(books=None, reset=False):
 
         if not found:
             logger.debug("Searches for %s returned no results." % book['searchterm'])
-        else:
+        if found > True:
             tor_count = tor_count + 1
 
     logger.info("TORSearch for Wanted items complete, found %s book%s" % (tor_count, plural(tor_count)))
@@ -205,7 +205,7 @@ def processResultList(resultlist, book, searchtype):
                                     newValueDict["BookID"]).fetchone()
         if snatchedbooks:
             logger.debug('%s already marked snatched' % nzb_Title)
-            return False
+            return True  # someone else found it, not us
         else:
             myDB.upsert("wanted", newValueDict, controlValueDict)
             snatch = TORDownloadMethod(newValueDict["BookID"], newValueDict["NZBprov"],
@@ -213,7 +213,7 @@ def processResultList(resultlist, book, searchtype):
             if snatch:
                 notify_snatch(newValueDict["NZBtitle"] + ' at ' + now())
                 scheduleJob(action='Start', target='processDir')
-                return True
+                return True + True  # we found it
     else:
         logger.debug("No torrent's found for " + (book["authorName"] + ' ' +
                  book['bookName']).strip() + " using searchtype " + searchtype)

--- a/lazylibrarian/searchtorrents.py
+++ b/lazylibrarian/searchtorrents.py
@@ -201,19 +201,21 @@ def processResultList(resultlist, book, searchtype):
         logger.info(u'Best match TOR (%s%%): %s using %s search' %
             (score, nzb_Title, searchtype))
 
-        myDB.upsert("wanted", newValueDict, controlValueDict)
-
         snatchedbooks = myDB.action('SELECT * from books WHERE BookID="%s" and Status="Snatched"' %
                                     newValueDict["BookID"]).fetchone()
-        if not snatchedbooks:
+        if snatchedbooks:
+            logger.debug('%s already marked snatched' % nzb_Title)
+            return False
+        else:
+            myDB.upsert("wanted", newValueDict, controlValueDict)
             snatch = TORDownloadMethod(newValueDict["BookID"], newValueDict["NZBprov"],
                                            newValueDict["NZBtitle"], controlValueDict["NZBurl"])
             if snatch:
                 notify_snatch(newValueDict["NZBtitle"] + ' at ' + now())
                 scheduleJob(action='Start', target='processDir')
                 return True
-
-    logger.debug("No torrent's found for " + (book["authorName"] + ' ' +
+    else:
+        logger.debug("No torrent's found for " + (book["authorName"] + ' ' +
                  book['bookName']).strip() + " using searchtype " + searchtype)
     return False
 

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -626,7 +626,12 @@ class WebInterface(object):
                 worklink = ''
                 if row[11]: # is there a workpage link
                     if len(row[11]) > 4:
-                        worklink = '<br><td><a href="' + row[11] + '" target="_new">WorkPage</a></td>'
+                        worklink = '<td><a href="' + row[11] + '" target="_new"><i class="smalltext">LibraryThing</i></a></td>'
+
+                if 'goodreads' in row[10]:
+                    sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoodReads</i></a></td>'
+                if 'google' in row[10]:
+                    sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoogleBooks</i></a></td>'
 
                 if lazylibrarian.HTTP_LOOK == 'default':
                     l.append(
@@ -636,11 +641,10 @@ class WebInterface(object):
                     l.append(
                         '<td id="authorname"><a href="authorPage?AuthorID=%s">%s</a></td>' % (row[12], row[1]))
                     if row[9]:  # is there a sub-title
-                        l.append(
-                          '<td id="bookname"><a href="%s" target="_new">%s</a><br><i class="smalltext">%s</i></td>' % (row[10], row[2], row[9]))
+                        title = '<td id="bookname">%s<br><i class="smalltext">%s</i></td>' % (row[2], row[9])
                     else:
-                        l.append(
-                            '<td id="bookname"><a href="%s" target="_new">%s</a></td>' % (row[10], row[2]))
+                        title = '<td id="bookname">%s</td>' % row[2]
+                    l.append(title + '<br>' + sitelink + '&nbsp;' + worklink)
 
                     if row[3]:  # is the book part of a series
                         l.append('<td id="series">%s</td>' % row[3])
@@ -665,7 +669,7 @@ class WebInterface(object):
                         btn = '<td id="status"><a class="button">%s</a></td>' % row[7]
                     else:
                         btn = '<td id="status"><a class="button grey">%s</a></td>' % row[7]
-                    l.append(btn + worklink)
+                    l.append(btn)
 
                 elif lazylibrarian.HTTP_LOOK == 'bookstrap':
                     l.append(
@@ -675,11 +679,10 @@ class WebInterface(object):
                     l.append(
                         '<td class="authorname"><a href="authorPage?AuthorID=%s">%s</a></td>' % (row[12], row[1]))
                     if row[9]:  # is there a sub-title
-                        l.append(
-                            '<td class="bookname"><a href="%s" target="_blank" rel="noreferrer">%s</a><br><i class="smalltext">%s</i></td>' % (row[10], row[2], row[9]))
+                        title = '<td class="bookname">%s<br><i class="smalltext">%s</i></td>' % (row[2], row[9])
                     else:
-                        l.append(
-                            '<td class="bookname"><a href="%s" target="_blank" rel="noreferrer">%s</a></td>' % (row[10], row[2]))
+                        title = '<td class="bookname">%s</td>' % row[2]
+                    l.append(title + '<br>' + sitelink + '&nbsp;' + worklink)
 
                     if row[3]:  # is the book part of a series
                         l.append('<td class="series">%s</td>' % row[3])
@@ -703,7 +706,7 @@ class WebInterface(object):
                         btn = '<td class="status text-center"><a class="button btn btn-xs btn-info">%s</a></td>' % row[7]
                     else:
                        btn = '<td class="status text-center"><a class="button btn btn-xs btn-default grey">%s</a></td>' % row[7]
-                    l.append(btn + worklink)
+                    l.append(btn)
 
                 d.append(l)  # add the rowlist to the masterlist
 

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -624,16 +624,17 @@ class WebInterface(object):
                     starimg = '0-stars.png'
 
                 worklink = ''
-                if row[11]: # is there a workpage link
-                    if len(row[11]) > 4:
-                        worklink = '<td><a href="' + row[11] + '" target="_new"><i class="smalltext">LibraryThing</i></a></td>'
-
-                if 'goodreads' in row[10]:
-                    sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoodReads</i></a></td>'
-                if 'google' in row[10]:
-                    sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoogleBooks</i></a></td>'
 
                 if lazylibrarian.HTTP_LOOK == 'default':
+                    if row[11]: # is there a workpage link
+                        if len(row[11]) > 4:
+                            worklink = '<td><a href="' + row[11] + '" target="_new"><i class="smalltext">LibraryThing</i></a></td>'
+
+                    if 'goodreads' in row[10]:
+                        sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoodReads</i></a></td>'
+                    if 'google' in row[10]:
+                        sitelink = '<td><a href="' + row[10] + '" target="_new"><i class="smalltext">GoogleBooks</i></a></td>'
+
                     l.append(
                         '<td id="select"><input type="checkbox" name="%s" class="checkbox" /></td>' % row[8])
                     l.append(
@@ -672,6 +673,15 @@ class WebInterface(object):
                     l.append(btn)
 
                 elif lazylibrarian.HTTP_LOOK == 'bookstrap':
+                    if row[11]: # is there a workpage link
+                        if len(row[11]) > 4:
+                            worklink = '<td><a href="' + row[11] + '" target="_new"><small><i>LibraryThing</i></small></a></td>'
+
+                    if 'goodreads' in row[10]:
+                        sitelink = '<td><a href="' + row[10] + '" target="_new"><small><i>GoodReads</i></small></a></td>'
+                    if 'google' in row[10]:
+                        sitelink = '<td><a href="' + row[10] + '" target="_new"><small><i>GoogleBooks</i></small></a></td>'
+
                     l.append(
                         '<td class="select"><input type="checkbox" name="%s" class="checkbox" /></td>' % row[8])
                     l.append(
@@ -679,7 +689,7 @@ class WebInterface(object):
                     l.append(
                         '<td class="authorname"><a href="authorPage?AuthorID=%s">%s</a></td>' % (row[12], row[1]))
                     if row[9]:  # is there a sub-title
-                        title = '<td class="bookname">%s<br><i class="smalltext">%s</i></td>' % (row[2], row[9])
+                        title = '<td class="bookname">%s<br><small><i>%s</i></small></td>' % (row[2], row[9])
                     else:
                         title = '<td class="bookname">%s</td>' % row[2]
                     l.append(title + '<br>' + sitelink + '&nbsp;' + worklink)
@@ -1560,11 +1570,26 @@ class WebInterface(object):
 
                 l.append('<td id="select"><input type="checkbox" name="%s" class="checkbox" /></td>' % row[5])
                 l.append('<td id="authorname"><a href="authorPage?AuthorID=%s">%s</a></td>' % (row[8], row[0]))
+                if lazylibrarian.HTTP_LOOK == 'default':
+                    if 'goodreads' in row[6]:
+                        sitelink = '<a href="' + row[6] + '" target="_new"><i class="smalltext">GoodReads</i></a>'
+                    if 'google' in row[6]:
+                        sitelink = '<a href="' + row[6] + '" target="_new"><i class="smalltext">GoogleBooks</i></a>'
 
-                if row[7]:  # is there a sub-title
-                    l.append('<td id="bookname"><a href="%s" target="_new">%s</a><br><i class="smalltext">%s</i></td>' % (row [6], row[1], row[7]))
-                else:
-                    l.append('<td id="bookname"><a href="%s" target="_new">%s</a></td>' % (row[6], row[1]))
+                    if row[7]:  # is there a sub-title
+                        l.append('<td id="bookname">%s<br><i class="smalltext">%s</i><br>%s</td>' % (row[1], row[7], sitelink))
+                    else:
+                        l.append('<td id="bookname">%s<br>%s</td>' % (row[1], sitelink))
+                elif lazylibrarian.HTTP_LOOK == 'bookstrap':
+                    if 'goodreads' in row[6]:
+                        sitelink = '<a href="' + row[6] + '" target="_new"><small><i>GoodReads</i></small></a>'
+                    if 'google' in row[6]:
+                        sitelink = '<a href="' + row[6] + '" target="_new"><small><i>GoogleBooks</i></small></a>'
+
+                    if row[7]:  # is there a sub-title
+                        l.append('<td id="bookname">%s<br><small><i>%s</i></small><br>%s</td>' % (row[1], row[7], sitelink))
+                    else:
+                        l.append('<td id="bookname">%s<br>%s</td>' % (row[1], sitelink))
 
                 if row[2]:  # is the book part of a series
                     l.append('<td id="series">%s</td>' % row[2])

--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -890,11 +890,12 @@ class WebInterface(object):
                             'AuthorLink': authordata[0]['AuthorLink']
                         }
                         myDB.upsert("books", newValueDict, controlValueDict)
-
+                        update_totals(bookdata[0]["AuthorID"])    # we moved from here
+                        update_totals(authordata[0]['AuthorID'])  # to here
 
                     logger.info('Book [%s] has been moved' % bookname)
                 else:
-                    logger.info('Book [%s] has not been moved' % bookname)
+                    logger.debug('Book [%s] has not been moved' % bookname)
 
         raise cherrypy.HTTPRedirect("authorPage?AuthorID=%s" % bookdata[0]["AuthorID"])
 


### PR DESCRIPTION
Allows author merging, among other things...
eg if you have Robert Heinlein, Robert A Heinlein, Robert Anson Heinlein in your library, you can take each book by Robert Heinlein or Robert Anson Heinlein, and move them so they appear under Robert A Heinlein

Also allows changing book title, series name, series number in case of mis-interpretation by the auto import routines

To use it, select the author. LL will list all the authors books, and under each book title are links to web pages and an "edit" page. At the moment you need to edit each book individually.

When you select "edit" you get a drop down box to change author, or type new entries for the other fields.  At the bottom of the page select "Save" to update the database, or navigate away from the page to keep existing values. There is also a "Lock" button. If the lock button is not ticked, the next library scan or refresh author will reload the original settings and your edits will be lost.

Suggested method of use:
For each book by Robert Heinlein or Robert Anson Heinlein that you have, or you want, edit the book and move it to Robert A Heinlein, with "lock" ticked. Duplicates, or books you don't want, can be left under  Robert Heinlein or Robert Anson Heinlein. Once you have finished moving all the ones you want, set Robert Heinlein or Robert Anson Heinlein to "Paused" so we don't reload them on a scan.

Actually, thinking about it, I might add an "Ignored" option to authors, so you an stop Robert Heinlein or Robert Anson Heinlein appearing in the list of available authors. 
