### PR TITLE
Changed init script to not clash with other apps

### DIFF
--- a/init/ubuntu.initd
+++ b/init/ubuntu.initd
@@ -11,7 +11,7 @@
 ################################################
 
 ### BEGIN INIT INFO
-# Provides:          LazyLibrarian application instance
+# Provides:          LazyLibrarian
 # Required-Start:    $all
 # Required-Stop:     $all
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
A few other apps have the word 'application' in their Provides line. The standard appears to be just a single word so changing to 'LazyLibrarian' should stop these clashes. I doubt many people are using this file now on new installs but just for completeness. (im assuming the extra words are just cosmetic!)

The error generated when doing a 'update-rc.d' is:

insserv: script lazylibrarian: service application already provided!
insserv: exiting now!
update-rc.d: error: insserv rejected the script header