### PR TITLE
Update base.html

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -17,7 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
     <link rel="shortcut icon" type="image/png"  href="images/favicon.ico">
-    <link rel="apple-touch-icon" href="images/templogo.png">
+    <link rel="apple-touch-icon" href="images/ll.png">
     <link rel="stylesheet" href="css/style.css?v=2">
     <script type="text/javascript" src="js/mootools.js"></script>
     <script type="text/javascript" src="js/mootools_more.js"></script>


### PR DESCRIPTION
Updated "apple-touch-icon" attribute in both default & bookstrap interfaces to point to ll.png instead of nonexistent tempicon.png.