### PR TITLE
Fixed syntax error when removing an author

### DIFF
--- a/lazylibrarian/webServe.py
+++ b/lazylibrarian/webServe.py
@@ -545,7 +545,7 @@ class WebInterface(object):
         if authorsearch:  # to stop error if try to remove an author while they are still loading
             AuthorName = authorsearch['AuthorName']
             logger.info(u"Removing all references to author: %s" % AuthorName)
-            myDB.action('DELETE from authors WHERE AuthorID=', (AuthorID,))
+            myDB.action('DELETE from authors WHERE AuthorID=?', (AuthorID,))
             myDB.action('DELETE from seriesauthors WHERE AuthorID=?', (AuthorID,))
             myDB.action('DELETE from books WHERE AuthorID=?', (AuthorID,))
         raise cherrypy.HTTPRedirect("home")


### PR DESCRIPTION
The missing `?` caused a SQL syntax error:

Traceback (most recent call last):
  File "/LazyLibrarian/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/LazyLibrarian/cherrypy/lib/encoding.py", line 217, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/LazyLibrarian/cherrypy/_cpdispatch.py", line 61, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/LazyLibrarian/lazylibrarian/webServe.py", line 548, in removeAuthor
    myDB.action('DELETE from authors WHERE AuthorID=', (AuthorID,))
  File "/LazyLibrarian/lazylibrarian/database.py", line 48, in action
    sqlResult = self.connection.execute(query, args)
OperationalError: near "=": syntax error