### PR TITLE
Enable links to series page from authors page

### DIFF
--- a/data/interfaces/bookstrap/author.html
+++ b/data/interfaces/bookstrap/author.html
@@ -213,6 +213,16 @@
                         'render': function(data, type, row) {
                         return '<a href="' + data + '" target="_blank" rel="noreferrer"><img src="' + data + '" alt="Cover" class="bookcover-sm img-responsive"></a>';} },
                     { targets: [2], class: "hidden" },
+                    { targets: [4], 'render': function(data, type, row){
+                        if (row[12] === null ) { return data; }
+                        var series = row[12].split('^');
+                        var output = [];
+                        for (var index=0; index < series.length; ++index) {
+                            var link_data = series[index].split("~");
+                            output.push('<a href=seriesMembers?seriesid=' + link_data[0] + '>' + link_data[1] + '</a>')
+                        }
+                        return output.join('<br>');
+                    }},
                     { targets: [5], 'render': function(data, type, row) {
                         return '<img src="images/' + data + '-stars.png" alt="Rating">';} },
                     { targets: [7], 'render': function(data, type, row) {


### PR DESCRIPTION
I just started to use this repository and noticed navigation was not fully connected between pages.  This pull request allows the web page user to jump from the Authors page to the Series page the book is linked too.

I also added `@cherrypy.tools.json_out()` to the header of the function to enable the API endpoint to be returned as a context type of "application/json".