### PR TITLE
Log detail

### DIFF
--- a/data/interfaces/bookstrap/logs.html
+++ b/data/interfaces/bookstrap/logs.html
@@ -18,8 +18,17 @@
 </%def>
 <%def name="body()">
   <h1>${title}</h1>
+  <style>
+    DIV#main.main.container { width: 90%; }
+  </style>
   %if lazylibrarian.CONFIG['TOGGLES'] == True:
-  Toggle: <a class="toggle-vis" data-column="0">Timestamp</a> - <a class="toggle-vis" data-column="1">Level</a> - <a class="toggle-vis" data-column="2">Message</a>
+  Toggle: <a class="toggle-vis" data-column="0">Timestamp</a>
+        - <a class="toggle-vis" data-column="1">Level</a>
+        - <a class="toggle-vis" data-column="2">Thread</a>
+        - <a class="toggle-vis" data-column="3">File</a>
+        - <a class="toggle-vis" data-column="4">Method</a>
+        - <a class="toggle-vis" data-column="5">Line No</a>
+        - <a class="toggle-vis" data-column="6">Message</a>
   %endif
   <div align="center">Refresh rate:
     <select id="refreshrate" class="button btn btn-sm btn-primary" onchange="setRefresh()">
@@ -37,6 +46,10 @@
         <tr>
           <th class="timestamp">Timestamp</th>
           <th class="level">Level</th>
+          <th class="thead">Thread</th>
+          <th class="file">File</th>
+          <th class="method">Method</th>
+          <th class="lineno">Line No</th>
           <th class="message">Message</th>
         </tr>
       </thead>

--- a/data/interfaces/default/logs.html
+++ b/data/interfaces/default/logs.html
@@ -31,9 +31,13 @@
   <table class="display" id="log_table">
     <thead>
       <tr>
-        <th id="timestamp">Timestamp</th>
-        <th id="level">Level</th>
-        <th id="message">Message</th>
+          <th class="timestamp">Timestamp</th>
+          <th class="level">Level</th>
+          <th class="thead">Thread</th>
+          <th class="file">File</th>
+          <th class="method">Method</th>
+          <th class="lineno">Line No</th>
+          <th class="message">Message</th>
       </tr>
     </thead>
   </table>

--- a/data/interfaces/default/logs.html
+++ b/data/interfaces/default/logs.html
@@ -55,6 +55,10 @@
         var oTable = $('#log_table').dataTable(
             {
                 "bAutoWidth": false,
+                "aoColumnDefs": [
+                    { "sWidth": "3%", "aTargets": [ 0,1,2,3,4,5 ] },
+                    { "sWidth": "60%", "aTargets": [ 6 ] }
+                ],
                 "oLanguage": {
                     "sSearch":"",
                     "sLengthMenu":"Show _MENU_ rows per page",


### PR DESCRIPTION
This PR adds extra details in the logging output to help chase down the location of which function/line was called when the message was written to the logger.  

I overrode the width of the **logs.html** page to be 90% of the screen,  bootstrap max width by default is 1170px when your screen width is 1200 or larger.

**Note:** Can we get rid of the old style _**default**_ html pages ? 
They are dependent on some really old JS code .. eg .. datatables.js 1.8.2.   It took me a while to track down documentation on how to adjust the column widths.
