### PR TITLE
Changed default theme to bookstrap

### DIFF
--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -178,7 +178,7 @@ CONFIG_DEFINITIONS = {
     'HTTP_PASS': ('str', 'General', ''),
     'HTTP_PROXY': ('bool', 'General', 0),
     'HTTP_ROOT': ('str', 'General', ''),
-    'HTTP_LOOK': ('str', 'General', 'default'),
+    'HTTP_LOOK': ('str', 'General', 'bookstrap'),
     'HTTPS_ENABLED': ('bool', 'General', 0),
     'HTTPS_CERT': ('str', 'General', ''),
     'HTTPS_KEY': ('str', 'General', ''),


### PR DESCRIPTION
I setup a separate instance of LL to do some testing with my setup this weekend, and as I left the theme as 'default' I realized many of the new features being developed are not being put into default (ex: Goodreads Sync)

As the default theme is a legacy 'artifact' of Headphones and new features are only being developed for Bookstrap I feel the default theme should be Bookstrap. 

This way future users will have no trouble finding any of the key features, and default could be left for users who encounter UI errors. I'll take a stab at giving the Wiki some attention in the coming weeks.