### PR TITLE
Fix manual search issues

### DIFF
--- a/lazylibrarian/manualbook.py
+++ b/lazylibrarian/manualbook.py
@@ -124,9 +124,6 @@ def searchItem(item=None, bookid=None, cat=None):
             words -= len(getList(title))
             score -= abs(words)
             if score >= 40:  # ignore wildly wrong results?
-                if not url.startswith('magnet'):
-                    if not mode == 'torznab' and not mode == 'direct':  # what is this split for??
-                        url = url.split('?')[0]
                 result = {'score': score, 'title': title, 'provider': provider, 'size': size, 'date': date,
                           'url': quote_plus(url), 'mode': mode}
 


### PR DESCRIPTION
I was having problems when using NZBHydra and a manual search - NZBHydra and a lot of nzb indexers respond with a link that looks something like `http://localhost:5075/getnzb?apikey=xxxx&searchresultid=xxxx`, and indexers sometimes respond with something like `http://indexer/getnzb?apikey=xxx`

Stripping the query string from the URL thus breaks the functionality, sending `http://localhost:5075/getnzb` without any more info straight to SABNzbd just makes it try over again to try and retreive the nzb from hydra. This also is not the behavior implemented in the automatic search, as when i tried there it sends the correct link without issue.

It seems like there is no justification for this code (maybe it was added to prettify the search results?, introduced in f43cb5d68627542c1cf4fa707045fa1fd26f49f7), as if the NZB case is removed, that only leaves the `torrent` case from what I can see, but it is likely that for some (possibly future) torrent sites it causes a similar bug.

I've elected to remove the code, which might be a harsh decision on my part and I can change it to simply disable for NZBs. I don't think removing vital information from the URL is the way to go in any case.