### PR TITLE
Correct postprocess to get real time of task

### DIFF
--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -845,7 +845,7 @@ def processDir(reset=False, startdir=None, ignoreclient=False):
                 try:
                     when_snatched = datetime.datetime.strptime(book['NZBdate'], '%Y-%m-%d %H:%M:%S')
                     timenow = datetime.datetime.now()
-                    td = when_snatched - timenow
+                    td = timenow - when_snatched
                     diff = td.seconds  # time difference in seconds
                 except ValueError:
                     diff = 0


### PR DESCRIPTION
Time since task has started was not correctly calculated. 

For issue https://github.com/DobyTang/LazyLibrarian/issues/1410