### PR TITLE
Fixed OPF file writing (and added ratings to the files)

### DIFF
--- a/lazylibrarian/api.py
+++ b/lazylibrarian/api.py
@@ -380,7 +380,7 @@ class Api(object):
         else:
             self.id = kwargs['id']
             myDB = database.DBConnection()
-            cmd = 'SELECT AuthorName,BookID,BookName,BookDesc,BookIsbn,BookImg,BookDate,BookLang,BookPub,BookFile'
+            cmd = 'SELECT AuthorName,BookID,BookName,BookDesc,BookIsbn,BookImg,BookDate,BookLang,BookPub,BookFile,BookRate'
             cmd += ' from books,authors WHERE BookID=? and books.AuthorID = authors.AuthorID'
             res = myDB.match(cmd, (kwargs['id'],))
             if not res:


### PR DESCRIPTION
The sqlite3 row object doesn't implement the right methods to allow the 'in' operator to work.  So all of the optional fields were never written out.

I added a hack to turn the row object into a normal map so that things work properly.

I also added support for writing out the ratings.