### PR TITLE
freebsd.initd: Add more rc.conf control and checks

### DIFF
--- a/init/freebsd.initd
+++ b/init/freebsd.initd
@@ -33,25 +33,41 @@ load_rc_config ${name}
 : ${lazylibrarian_user:="USERNAME"}
 : ${lazylibrarian_dir:="/usr/local/lazylibrarian"}
 : ${lazylibrarian_chdir:="${lazylibrarian_dir}"}
-: ${lazylibrarian_pid:="${lazylibrarian_dir}/lazylibrarian.pid"}
+: ${lazylibrarian_datadir:="${lazylibrarian_dir}"}
+: ${lazylibrarian_pid:="${lazylibrarian_datadir}/lazylibrarian.pid"}
+: ${lazylibrarian_conf:="${lazylibrarian_datadir}/config.ini"}
+: ${lazylibrarian_flags:=""}
+
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
-WGET="/usr/local/bin/wget"      # You need wget for this script to safely shutdown couchpotato.
-HOST="localhost"                # Set LazyLibrarian address here.
-PORT="5299"                     # Set LazyLibrarian port here.
+WGET="/usr/local/bin/wget"      # You need wget for this script to safely shutdown lazylibrarian.
 LLUSR=""                        # Set LazyLibrarian username (if you use one) here.
 LLPWD=""                        # Set LazyLibrarian password (if you use one) here.
+
+if [ -e "${lazylibrarian_conf}" ]; then
+    HOST=`grep -A128 "\[General\]" "${lazylibrarian_conf}"|egrep "^http_host"|perl -wple 's/^http_host = (.*)$/$1/'`
+    PORT=`grep -A128 "\[General\]" "${lazylibrarian_conf}"|egrep "^http_port"|perl -wple 's/^http_port = (.*)$/$1/'`
+else
+    HOST="localhost"
+    PORT="5299"
+fi
 
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
-command="/usr/sbin/daemon"
-command_args="-f -p ${lazylibrarian_pid} python ${lazylibrarian_dir}/LazyLibrarian.py ${lazylibrarian_flags} --quiet"
+command="${lazylibrarian_dir}/LazyLibrarian.py"
+command_args="--daemon --quiet --pidfile ${lazylibrarian_pid} --datadir ${lazylibrarian_datadir} ${lazylibrarian_flags}"
+
+# Check for wget and refuse to start without it.
+if [ ! -x "${WGET}" ]; then
+    warn "lazylibrarian not started: You need wget to safely shut down lazylibrarian."
+    exit 1
+fi
 
 # Ensure user is root when running this script.
 if [ `id -u` != "0" ]; then
-  echo "Oops, you should be root before running this!"
-  exit 1
+    echo "Oops, you should be root before running this!"
+    exit 1
 fi
 
 verify_lazylibrarian_pid() {
@@ -67,8 +83,8 @@ lazylibrarian_stop() {
     verify_lazylibrarian_pid
     ${WGET} -O - -q --user=${LLUSR} --password=${LLPWD} "http://${HOST}:${PORT}/shutdown/" >/dev/null
     if [ -n "${pid}" ]; then
-      wait_for_pids ${pid}
-      echo "Stopped"
+        wait_for_pids ${pid}
+        echo "Stopped"
     fi
 }
 


### PR DESCRIPTION
I've been running with these modifications for quite a while now on my Freenas server (freebsd 11 jails).

* Adds more rc.conf control allowing --datadir and custom flags to be passed to lazylibrarian.  This is useful on Freenas where data is stored in a zfs dataset outside of the jail running lazylibrarian.
* Add startup check that wget exists since stop does not work without it.
* Use the host/port specified in config.ini (if found), otherwise fall back to original defaults
 