### PR TITLE
Removed escaping from placeholder parameters in SQL

### DIFF
--- a/lazylibrarian/gb.py
+++ b/lazylibrarian/gb.py
@@ -200,8 +200,7 @@ class GoogleBooks:
                             AuthorID = ''
                             if book['author']:
                                 match = myDB.match(
-                                    'SELECT AuthorID FROM authors WHERE AuthorName=?', (
-                                        book['author'].replace('"', '""'),))
+                                    'SELECT AuthorID FROM authors WHERE AuthorName=?', (book['author'],))
                                 if match:
                                     AuthorID = match['AuthorID']
 
@@ -421,7 +420,7 @@ class GoogleBooks:
                         if not rejected:
                             cmd = 'SELECT BookID FROM books,authors WHERE books.AuthorID = authors.AuthorID'
                             cmd += ' and BookName=? COLLATE NOCASE and AuthorName=? COLLATE NOCASE'
-                            match = myDB.match(cmd, (bookname.replace('"', '""'), authorname.replace('"', '""')))
+                            match = myDB.match(cmd, (bookname, authorname))
                             if match:
                                 if match['BookID'] != bookid:  # we have a different book with this author/title already
                                     logger.debug('Rejecting bookid %s for [%s][%s] already got %s' %
@@ -602,7 +601,7 @@ class GoogleBooks:
             logger.debug("Imported/Updated %s book%s for author" % (resultcount, plural(resultcount)))
 
             myDB.action('insert into stats values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-                        (authorname.replace('"', '""'), api_hits, gr_lang_hits, lt_lang_hits, gb_lang_change,
+                        (authorname, api_hits, gr_lang_hits, lt_lang_hits, gb_lang_change,
                          cache_hits, ignored, removedResults, not_cached, duplicates))
 
             if refresh:

--- a/lazylibrarian/gr.py
+++ b/lazylibrarian/gr.py
@@ -706,7 +706,7 @@ class GoodReads:
                         if not rejected:
                             cmd = 'SELECT BookID FROM books,authors WHERE books.AuthorID = authors.AuthorID'
                             cmd += ' and BookName=? COLLATE NOCASE and AuthorName=? COLLATE NOCASE'
-                            match = myDB.match(cmd, (bookname, authorNameResult.replace('"', '""')))
+                            match = myDB.match(cmd, (bookname, authorNameResult,))
                             if match:
                                 if match['BookID'] != bookid:
                                     # we have a different bookid for this author/title already

--- a/lazylibrarian/importer.py
+++ b/lazylibrarian/importer.py
@@ -42,11 +42,11 @@ def addAuthorNameToDB(author=None, refresh=False, addbooks=True):
     myDB = database.DBConnection()
 
     # Check if the author exists, and import the author if not,
-    check_exist_author = myDB.match('SELECT AuthorID FROM authors where AuthorName=?', (author.replace('"', '""'),))
+    check_exist_author = myDB.match('SELECT AuthorID FROM authors where AuthorName=?', (author,))
 
     # If no exact match, look for a close fuzzy match to handle misspellings, accents
     if not check_exist_author:
-        match_name = author.replace('"', '""').lower()
+        match_name = author.lower()
         res = myDB.action('select AuthorID,AuthorName from authors')
         for item in res:
             aname = item['AuthorName']
@@ -191,11 +191,9 @@ def addAuthorToDB(authorname=None, refresh=False, authorid=None, addbooks=True):
             GR = GoodReads(authorname)
             author = GR.find_author_id(refresh=refresh)
 
-            query = "SELECT * from authors WHERE AuthorName=?"
-            dbauthor = myDB.match(query, (authorname.replace("'", "''"),))
+            dbauthor = myDB.match("SELECT * from authors WHERE AuthorName=?", (authorname,))
             if author and not dbauthor:  # may have different name for same authorid (spelling?)
-                query = "SELECT * from authors WHERE AuthorID=?"
-                dbauthor = myDB.match(query, (author['authorid'],))
+                dbauthor = myDB.match("SELECT * from authors WHERE AuthorID=?", (author['authorid'],))
                 authorname = dbauthor['AuthorName']
 
             controlValueDict = {"AuthorName": authorname}

--- a/lazylibrarian/librarysync.py
+++ b/lazylibrarian/librarysync.py
@@ -173,7 +173,7 @@ def find_book_in_db(author, book, ignored=None):
     myDB = database.DBConnection()
     cmd = 'SELECT BookID,books.Status FROM books,authors where books.AuthorID = authors.AuthorID'
     cmd += ' and AuthorName=? COLLATE NOCASE and BookName=? COLLATE NOCASE'
-    res = myDB.select(cmd, (author.replace('"', '""'), book.replace('"', '""')))
+    res = myDB.select(cmd, (author, book))
     match = None
     for item in res:
         if item['Status'] == 'Have':
@@ -208,7 +208,7 @@ def find_book_in_db(author, book, ignored=None):
         elif ignored is False:
             cmd += 'and books.Status != "Ignored" '
         cmd += 'and AuthorName=? COLLATE NOCASE'
-        books = myDB.select(cmd, (author.replace('"', '""'),))
+        books = myDB.select(cmd, (author,))
         best_ratio = 0
         best_partial = 0
         best_partname = 0
@@ -916,11 +916,11 @@ def LibraryScan(startdir=None, library='eBook', authid=None, remove=True):
                                                 # we found a new book
                                                 new_book_count += 1
                                                 myDB.action(
-                                                    'UPDATE books set Status="%s" where BookID=?' %
-                                                    lazylibrarian.CONFIG['FOUND_STATUS'], (bookid,))
+                                                    'UPDATE books set Status=? where BookID=?',
+                                                    (lazylibrarian.CONFIG['FOUND_STATUS'], bookid,))
                                                 myDB.action(
                                                     'UPDATE books set BookLibrary=? where BookID=?',
-                                                    (now(), bookid))
+                                                    (now(), bookid,))
 
                                             # check and store book location so we can check if it gets (re)moved
                                             book_filename = os.path.join(rootdir, files)
@@ -958,10 +958,11 @@ def LibraryScan(startdir=None, library='eBook', authid=None, remove=True):
                                                 # we found a new audiobook
                                                 new_book_count += 1
                                                 myDB.action(
-                                                    'UPDATE books set AudioStatus="%s" where BookID=?' %
-                                                    lazylibrarian.CONFIG['FOUND_STATUS'], (bookid,))
+                                                    'UPDATE books set AudioStatus=? where BookID=?',
+                                                    (lazylibrarian.CONFIG['FOUND_STATUS'], bookid,))
                                                 myDB.action(
-                                                    'UPDATE books set AudioLibrary=? where BookID=?', (now(), bookid))
+                                                    'UPDATE books set AudioLibrary=? where BookID=?',
+                                                    (now(), bookid))
                                             # store audiobook location so we can check if it gets (re)moved
                                             book_filename = os.path.join(rootdir, files)
                                             # link to the first part of multi-part audiobooks

--- a/lazylibrarian/opds.py
+++ b/lazylibrarian/opds.py
@@ -673,7 +673,7 @@ class OPDS(object):
                          'rel': 'file',
                          'type': mime_type}
                 if lazylibrarian.CONFIG['OPDS_METAINFO']:
-                    author = myDB.match("SELECT AuthorName from authors WHERE AuthorID='%s'" % book['AuthorID'])
+                    author = myDB.match("SELECT AuthorName from authors WHERE AuthorID=?", (book['AuthorID'],))
                     author = makeUnicode(author['AuthorName'])
                     entry['image'] = self.searchroot + '/' + book['BookImg']
                     entry['content'] = escape('%s - %s' % (title, book['BookDesc']))
@@ -735,7 +735,7 @@ class OPDS(object):
                      'rel': 'file',
                      'type': mimeType("we_send.zip")}
             if lazylibrarian.CONFIG['OPDS_METAINFO']:
-                author = myDB.match("SELECT AuthorName from authors WHERE AuthorID='%s'" % book['AuthorID'])
+                author = myDB.match("SELECT AuthorName from authors WHERE AuthorID=?", (book['AuthorID'],))
                 author = makeUnicode(author['AuthorName'])
                 entry['image'] = self.searchroot + '/' + book['BookImg']
                 entry['content'] = escape('%s - %s' % (title, book['BookDesc']))

--- a/lazylibrarian/rssfeed.py
+++ b/lazylibrarian/rssfeed.py
@@ -22,21 +22,21 @@ from lib.rfeed import Item, Guid, Feed
 def genFeed(ftype, limit=10, user=0, baseurl=''):
     if ftype == 'eBook':
         cmd = "select AuthorName,BookName,BookDesc,BookLibrary,BookID,BookLink from books,authors where"
-        cmd += " BookLibrary != '' and books.AuthorID = authors.AuthorID order by BookLibrary desc limit %s" % limit
+        cmd += " BookLibrary != '' and books.AuthorID = authors.AuthorID order by BookLibrary desc limit ?"
         baselink = baseurl + 'bookWall&have=1'
     elif ftype == 'AudioBook':
         cmd = "select AuthorName,BookName,BookDesc,AudioLibrary,BookID,BookLink from books,authors where"
-        cmd += " AudioLibrary != '' and books.AuthorID = authors.AuthorID order by AudioLibrary desc limit %s" % limit
+        cmd += " AudioLibrary != '' and books.AuthorID = authors.AuthorID order by AudioLibrary desc limit ?"
         baselink = baseurl + 'audioWall'
     elif ftype == 'Magazine':
-        cmd = "select Title,IssueDate,IssueAcquired,IssueID from issues order by IssueAcquired desc limit %s" % limit
+        cmd = "select Title,IssueDate,IssueAcquired,IssueID from issues order by IssueAcquired desc limit ?"
         baselink = baseurl + 'magWall'
     else:
         logger.debug("Invalid feed type")
         return None
 
     myDB = database.DBConnection()
-    results = myDB.select(cmd)
+    results = myDB.select(cmd, (limit,))
     items = []
     # logger.debug("Found %s %s results" % (len(results), ftype))
 


### PR DESCRIPTION
The code was effectively double escaping ... in some places.  It would
escape " to "" and pass it as a placeholder.  Then the DB code would
further escape that.  So 'E.E. "Doc" Smith' would not work corretly.

I looked at all DB commands across the code and fixed up any
placeholder related problems that I saw.  PRAGMA statements can not
have placeholders so I left them as they were.

There was also a change to a match, we were doing the same replacement
before we tried a match... but the response from the DB should not
have been escaped, so I stripped that out too.