### PR TITLE
Fixed join command in requesters

### DIFF
--- a/lazylibrarian/searchrss.py
+++ b/lazylibrarian/searchrss.py
@@ -77,11 +77,11 @@ def search_wishlist():
                         logger.info('Found book %s, already marked as "%s"' % (bookname, bookmatch['Status']))
                         if bookmatch["Requester"]:  # Already on a wishlist
                             if book["dispname"] not in bookmatch["Requester"]:
-                                newValueDict = {"Requester": ' '.join(bookmatch["Requester"], book["dispname"])}
+                                newValueDict = {"Requester": bookmatch["Requester"]+ book["dispname"] + ' '}
                                 controlValueDict = {"BookID": book['rss_bookid']}
                                 myDB.upsert("books", newValueDict, controlValueDict)
                         else:
-                            newValueDict = {"Requester": book["dispname"]}
+                            newValueDict = {"Requester": book["dispname"] + ' '}
                             controlValueDict = {"BookID": book['rss_bookid']}
                             myDB.upsert("books", newValueDict, controlValueDict)
                     elif ebook_status == "Wanted":  # skipped/ignored
@@ -92,22 +92,22 @@ def search_wishlist():
                         new_books += 1
                         if bookmatch["Requester"]:  # Already on a wishlist
                             if book["dispname"] not in bookmatch["Requester"]:
-                                newValueDict = {"Requester": ' '.join(bookmatch["Requester"], book["dispname"])}
+                                newValueDict = {"Requester": bookmatch["Requester"]+ book["dispname"] + ' '}
                                 controlValueDict = {"BookID": book['rss_bookid']}
                                 myDB.upsert("books", newValueDict, controlValueDict)
                         else:
-                            newValueDict = {"Requester": book["dispname"]}
+                            newValueDict = {"Requester": book["dispname"] + ' '}
                             controlValueDict = {"BookID": book['rss_bookid']}
                             myDB.upsert("books", newValueDict, controlValueDict)
                     if bookmatch['AudioStatus'] in ['Open', 'Wanted', 'Have']:
                         logger.info('Found audiobook %s, already marked as "%s"' % (bookname, bookmatch['AudioStatus']))
                         if bookmatch["AudioRequester"]:  # Already on a wishlist
                             if book["dispname"] not in bookmatch["AudioRequester"]:
-                                newValueDict = {"AudioRequester": ' '.join(bookmatch["AudioRequester"], book["dispname"])}
+                                newValueDict = {"AudioRequester": bookmatch["AudioRequester"]+ book["dispname"] + ' '}
                                 controlValueDict = {"BookID": book['rss_bookid']}
                                 myDB.upsert("books", newValueDict, controlValueDict)
                         else:
-                            newValueDict = {"AudioRequester": book["dispname"]}
+                            newValueDict = {"AudioRequester": book["dispname"] + ' '}
                             controlValueDict = {"BookID": book['rss_bookid']}
                             myDB.upsert("books", newValueDict, controlValueDict)
                     elif audio_status == "Wanted":  # skipped/ignored
@@ -118,20 +118,20 @@ def search_wishlist():
                         new_books += 1
                         if bookmatch["AudioRequester"]:  # Already on a wishlist
                             if book["dispname"] not in bookmatch["AudioRequester"]:
-                                newValueDict = {"AudioRequester": ' '.join(bookmatch["AudioRequester"], book["dispname"])}
+                                newValueDict = {"AudioRequester": bookmatch["AudioRequester"]+ book["dispname"] + ' '}
                                 controlValueDict = {"BookID": book['rss_bookid']}
                                 myDB.upsert("books", newValueDict, controlValueDict)
                         else:
-                            newValueDict = {"AudioRequester": book["dispname"]}
+                            newValueDict = {"AudioRequester": book["dispname"] + ' '}
                             controlValueDict = {"BookID": book['rss_bookid']}
                             myDB.upsert("books", newValueDict, controlValueDict)
                 else:
                     import_book(book['rss_bookid'], ebook_status, audio_status)
                     new_books += 1
-                    newValueDict = {"Requester": book["dispname"]}
+                    newValueDict = {"Requester": book["dispname"] + ' '}
                     controlValueDict = {"BookID": book['rss_bookid']}
                     myDB.upsert("books", newValueDict, controlValueDict)
-                    newValueDict = {"AudioRequester": book["dispname"]}
+                    newValueDict = {"AudioRequester": book["dispname"] + ' '}
                     controlValueDict = {"BookID": book['rss_bookid']}
                     myDB.upsert("books", newValueDict, controlValueDict)
             else:


### PR DESCRIPTION
' '.join(bookmatch["Requester"], book["dispname"])} was throwing errors.

2018-10-17 08:38:15	ERROR	WEBSERVER	searchrss.py	search_wishlist	257	Unhandled exception in search_wishlist: Traceback (most recent call last): File "C:\LazyLibrarian\lazylibrarian\searchrss.py", line 80, in search_wishlist newValueDict = {"Requester": ' '.join(bookmatch["Requester"], book["dispname"])} TypeError: join() takes exactly one argument (2 given)