### PR TITLE
Added config options for download OPF and wishlist tags

### DIFF
--- a/data/interfaces/bookstrap/config.html
+++ b/data/interfaces/bookstrap/config.html
@@ -1788,6 +1788,28 @@
                       <input type="checkbox" id="imp_autoadd_bookonly" name="imp_autoadd_bookonly" value="1" ${checked} />
                       Only add eBook, not opf or jpg</label>
                   </div>
+				  <div class="checkbox">
+                    <%
+                        if lazylibrarian.CONFIG['OPF_TAGS'] == True:
+                            checked = 'checked="checked"'
+                        else:
+                            checked = ''
+                    %>
+                    <label for="opf_tags">
+                      <input type="checkbox" id="opf_tags" name="opf_tags" value="1" ${checked} />
+                      Add tags included with download to Calibre</label>
+                  </div>
+				  <div class="checkbox">
+                    <%
+                        if lazylibrarian.CONFIG['WISHLIST_TAGS'] == True:
+                            checked = 'checked="checked"'
+                        else:
+                            checked = ''
+                    %>
+                    <label for="wishlist_tags">
+                      <input type="checkbox" id="wishlits_tags" name="wishlist_tags" value="1" ${checked} />
+                      Add wishlist name as tag to Calibre</label>
+                  </div>
                   </fieldset>
                   <fieldset>
                   <div class="form-group">

--- a/data/interfaces/legacy/config.html
+++ b/data/interfaces/legacy/config.html
@@ -1087,6 +1087,30 @@
               <BR>
               <small> Only add eBook, not opf or jpg</small>
             </div>
+			<div>
+              <%
+                    if lazylibrarian.CONFIG['OPF_TAGS'] == True:
+                        checked = 'checked="checked"'
+                    else:
+                        checked = ''
+                    %>
+              <input type="checkbox" id="opf_tags" name="opf_tags" value=1 ${checked} />
+              <label> Add OPF Tags</label>
+              <BR>
+              <small> Add downloaded tags to Calibre</small>
+            </div>
+			<div>
+              <%
+                    if lazylibrarian.CONFIG['WISHLIST_TAGS'] == True:
+                        checked = 'checked="checked"'
+                    else:
+                        checked = ''
+                    %>
+              <input type="checkbox" id="wishlist_tags" name="wishlist_tags" value=1 ${checked} />
+              <label> Add Wishlist Tags</label>
+              <BR>
+              <small> Add wishlist names as tags in Calibre</small>
+            </div>
             <div>
               <%
                     if lazylibrarian.CONFIG['FULL_SCAN'] == True:

--- a/lazylibrarian/__init__.py
+++ b/lazylibrarian/__init__.py
@@ -268,6 +268,8 @@ CONFIG_DEFINITIONS = {
     'GIT_PROGRAM': ('str', 'General', ''),
     'CACHE_AGE': ('int', 'General', 30),
     'TASK_AGE': ('int', 'General', 2),
+    'OPF_TAGS': ('bool', 'General', 1),
+    'WISHLIST_TAGS': ('bool', 'General', 1),
     'GIT_USER': ('str', 'Git', 'dobytang'),
     'GIT_REPO': ('str', 'Git', 'lazylibrarian'),
     'GIT_BRANCH': ('str', 'Git', 'master'),

--- a/lazylibrarian/postprocess.py
+++ b/lazylibrarian/postprocess.py
@@ -1590,18 +1590,19 @@ def processDestination(pp_path=None, dest_path=None, authorname=None, bookname=N
                     _, _, rc = calibredb('set_metadata', None, [calibre_id, opfpath])
                     if rc:
                         logger.warn("calibredb unable to set opf")
-                    if data['Requester'] is not None:
-                        _, _, rc = calibredb('set_metadata',
+                    if lazylibrarian.CONFIG['WISHLIST_TAGS']:
+                        if data['Requester'] is not None:
+                            _, _, rc = calibredb('set_metadata',
                                              ['--field', 'tags:%s' % data['Requester'].replace(" ", ",")],
                                              [calibre_id])
-                        if rc:
-                            logger.warn("calibredb unable to set Requester")
-                    if data['AudioRequester'] is not None:
-                        _, _, rc = calibredb('set_metadata',
+                            if rc:
+                                logger.warn("calibredb unable to set Requester")
+                        if data['AudioRequester'] is not None:
+                            _, _, rc = calibredb('set_metadata',
                                              ['--field', 'tags:%s' % data['AudioRequester'].replace(" ", ",")],
                                              [calibre_id])
-                        if rc:
-                            logger.warn("calibredb unable to set AudioRequester")
+                            if rc:
+                                logger.warn("calibredb unable to set AudioRequester")
 
             if not our_opf and not rc:  # pre-existing opf might not have our preferred authorname/title/identifier
                 _, _, rc = calibredb('set_metadata', ['--field', 'authors:%s' % unaccented(authorname)], [calibre_id])
@@ -1878,10 +1879,11 @@ def processMAGOPF(issuefile, title, issue, issueID, overwrite=False):
 
 def processOPF(dest_path=None, data=None, global_name=None, overwrite=False):
     opfpath = os.path.join(dest_path, global_name + '.opf')
-    if not overwrite and os.path.exists(opfpath):
-        logger.debug('%s already exists. Did not create one.' % opfpath)
-        setperm(opfpath)
-        return opfpath, False
+    if lazylibrarian.CONFIG['OPF_TAGS']:
+        if not overwrite and os.path.exists(opfpath):
+            logger.debug('%s already exists. Did not create one.' % opfpath)
+            setperm(opfpath)
+            return opfpath, False
 
     # Horrible hack to work around the limitations of sqlite3's row object
     data = {k: data[k] for k in data.keys()}


### PR DESCRIPTION
Made Wishlist tags optional in Processing tab of config.html for both layouts.  Also added an option to skip opf files that happened to be downloaded with the ebooks themselves.